### PR TITLE
fix: prevent EESession cross-event-loop failures

### DIFF
--- a/eeclient/cache.py
+++ b/eeclient/cache.py
@@ -45,7 +45,7 @@ class ResponseCache:
         self.ttl = ttl
         self.max_size = max_size
         self._cache: OrderedDict[str, CacheEntry] = OrderedDict()
-        self._lock = asyncio.Lock()
+        self._lock: Optional[asyncio.Lock] = None
 
     def make_cache_key(self, *args, **kwargs) -> str:
         """Generate a stable cache key from function arguments."""
@@ -66,6 +66,8 @@ class ResponseCache:
             The cached or freshly fetched result
         """
         # Check cache and get task reference if needed
+        if self._lock is None:
+            self._lock = asyncio.Lock()
         async with self._lock:
             if key in self._cache:
                 entry = self._cache[key]
@@ -108,6 +110,18 @@ class ResponseCache:
                 if key in self._cache:
                     self._cache[key] = CacheEntry(error=e)
             raise
+
+    def has_pending_tasks(self) -> bool:
+        """Return True if any cache entry has an in-flight task."""
+        return any(
+            entry.task is not None and not entry.task.done()
+            for entry in self._cache.values()
+        )
+
+    def _rebind(self):
+        """Create fresh loop-bound state for the current event loop."""
+        self._lock = asyncio.Lock()
+        self._cache.clear()
 
     def clear(self):
         """Clear all cached entries."""

--- a/eeclient/client.py
+++ b/eeclient/client.py
@@ -6,7 +6,7 @@ import httpx
 import logging
 from contextlib import asynccontextmanager
 
-from eeclient.exceptions import EEClientError, EERestException
+from eeclient.exceptions import EEClientError, EELoopError, EERestException
 from eeclient.models import GEEHeaders, SepalHeaders
 from eeclient.sepal_credential_mixin import SepalCredentialMixin
 from eeclient.cache import ResponseCache
@@ -37,12 +37,19 @@ VERIFY_SSL = True
 class SimpleRateLimiter:
     def __init__(self, qps: float | None):
         self.qps = qps
+        self._lock: asyncio.Lock | None = None
+        self._next = 0.0
+
+    def _rebind(self):
+        """Create fresh loop-bound state for the current event loop."""
         self._lock = asyncio.Lock()
         self._next = 0.0
 
     async def acquire(self):
         if not self.qps or self.qps <= 0:
             return
+        if self._lock is None:
+            self._lock = asyncio.Lock()
         async with self._lock:
             now = asyncio.get_running_loop().time()
             wait = max(0.0, self._next - now)
@@ -70,14 +77,13 @@ class EESession(SepalCredentialMixin):
         Raises:
             ValueError: If SEPAL_HOST environment variable is not set
         """
-        self._inflight = asyncio.BoundedSemaphore(30)
+        # Loop-bound state -- created lazily by _ensure_bound()
+        self._bound_loop: asyncio.AbstractEventLoop | None = None
+        self._inflight: asyncio.BoundedSemaphore | None = None
         self._rate = SimpleRateLimiter(60)
-
-        self._auth_refresh_lock = asyncio.Lock()
-
+        self._auth_refresh_lock: asyncio.Lock | None = None
         self._client: httpx.AsyncClient | None = None
-        self._client_lock = asyncio.Lock()
-
+        self._client_lock: asyncio.Lock | None = None
         self._assets_cache = ResponseCache(ttl=10.0, max_size=100)
 
         self.enforce_project_id = enforce_project_id
@@ -93,6 +99,61 @@ class EESession(SepalCredentialMixin):
             )
         )
 
+    _INFLIGHT_MAX = 30
+
+    def _has_active_work(self) -> bool:
+        """Return True if the session has any in-flight async activity."""
+        if self._inflight is not None and self._inflight._value < self._INFLIGHT_MAX:
+            return True
+        if self._assets_cache.has_pending_tasks():
+            return True
+        if self._client is not None and not self._client.is_closed:
+            return True
+        return False
+
+    def _bind(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Create all loop-bound async primitives for the given loop."""
+        self._bound_loop = loop
+        self._inflight = asyncio.BoundedSemaphore(self._INFLIGHT_MAX)
+        self._auth_refresh_lock = asyncio.Lock()
+        self._client_lock = asyncio.Lock()
+        self._client = None
+        self._rate._rebind()
+        self._assets_cache._rebind()
+
+    def _ensure_bound(self) -> None:
+        """Ensure the session is bound to the current event loop.
+
+        - First call: binds to the running loop.
+        - Same loop: no-op.
+        - Different loop, old loop idle: rebinds.
+        - Different loop, old loop busy: raises EELoopError.
+        """
+        loop = asyncio.get_running_loop()
+
+        if self._bound_loop is None:
+            self._bind(loop)
+            return
+
+        if self._bound_loop is loop:
+            return
+
+        # Different loop detected -- check whether rebinding is safe
+        if self._has_active_work():
+            raise EELoopError(
+                "EESession is bound to a different event loop that still has "
+                "active work (in-flight requests, pending cache tasks, or an "
+                "open HTTP client). Close the session or wait for all work to "
+                "complete before using it from a new event loop."
+            )
+
+        self.logger.debug(
+            "EESession rebinding from loop %r to loop %r",
+            self._bound_loop,
+            loop,
+        )
+        self._bind(loop)
+
     async def initialize(self) -> "EESession":
         """Asynchronously initialize the session by fetching credentials if needed.
 
@@ -102,6 +163,7 @@ class EESession(SepalCredentialMixin):
         Returns:
             EESession: The initialized session (self)
         """
+        self._ensure_bound()
         if not self._credentials:
             await self.set_credentials()
         return self
@@ -127,6 +189,7 @@ class EESession(SepalCredentialMixin):
         return await session.initialize()
 
     async def get_assets_folder(self) -> str:
+        self._ensure_bound()
         if self.needs_credentials_refresh():
             await self.set_credentials()
         return f"projects/{self.project_id}/assets/"
@@ -154,6 +217,7 @@ class EESession(SepalCredentialMixin):
         return GEEHeaders.model_validate(data)
 
     async def get_headers(self):
+        self._ensure_bound()
         # Only one task refreshes the token; others wait briefly.
         if self.needs_credentials_refresh():
             async with self._auth_refresh_lock:
@@ -162,6 +226,7 @@ class EESession(SepalCredentialMixin):
         return self.get_current_headers()
 
     async def _ensure_client(self) -> httpx.AsyncClient:
+        self._ensure_bound()
         if self._client is None:
             async with self._client_lock:
                 if self._client is None:
@@ -181,6 +246,19 @@ class EESession(SepalCredentialMixin):
         yield client
 
     async def aclose(self):
+        """Close the HTTP client and clear the cache.
+
+        Must be called from the loop the session is bound to.
+        Raises EELoopError if called from a different loop.
+        """
+        if self._bound_loop is not None:
+            loop = asyncio.get_running_loop()
+            if loop is not self._bound_loop:
+                raise EELoopError(
+                    "EESession.aclose() must be called from the event loop "
+                    "the session is bound to. Current loop and bound loop "
+                    "differ."
+                )
         if self._client is not None:
             await self._client.aclose()
             self._client = None
@@ -197,6 +275,7 @@ class EESession(SepalCredentialMixin):
         max_wait: float = 60,
     ) -> Dict[str, Any]:
         """Async REST call with retry logic"""
+        self._ensure_bound()
 
         attempt = 0
         last_error = None

--- a/eeclient/exceptions.py
+++ b/eeclient/exceptions.py
@@ -66,6 +66,12 @@ class CredentialsFileUnknownError(EEClientError):
         super().__init__(error)
 
 
+class EELoopError(EEClientError):
+    """Raised when an EESession is used from the wrong event loop."""
+
+    pass
+
+
 class SepalCredentialsUnavailableError(EEClientError):
     """Raised when SEPAL API cannot provide credentials (e.g., 500 error)."""
 

--- a/tests/test_loop_binding.py
+++ b/tests/test_loop_binding.py
@@ -1,0 +1,211 @@
+"""Tests for EESession event-loop binding contract (issue #14).
+
+Verifies:
+1. Normal same-loop use
+2. Rejection of concurrent second-loop use
+3. Rebinding only after the previous loop is fully idle
+4. Wrong-loop aclose() behavior
+5. Pending cache-task handling during attempted rebinding
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+from eeclient.cache import CacheEntry
+from eeclient.client import EESession
+from eeclient.exceptions import EELoopError
+
+
+@pytest.fixture(autouse=True)
+def _set_sepal_host(monkeypatch):
+    """EESession requires SEPAL_HOST when using sepal headers."""
+    monkeypatch.setenv("SEPAL_HOST", "test.sepal.io")
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Normal same-loop use
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_same_loop_use(dummy_headers):
+    """Session binds on first async call; subsequent calls on the same loop work."""
+    session = EESession(sepal_headers=dummy_headers)
+    assert session._bound_loop is None
+
+    # First async entry point binds the session
+    session._ensure_bound()
+    loop = asyncio.get_running_loop()
+    assert session._bound_loop is loop
+    assert session._inflight is not None
+    assert session._auth_refresh_lock is not None
+    assert session._client_lock is not None
+
+    # Second call on the same loop is a no-op
+    session._ensure_bound()
+    assert session._bound_loop is loop
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Rejection of concurrent second-loop use
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_second_loop_rejected(dummy_headers):
+    """Using the session from a second loop while the first has active work raises."""
+    loop_a = asyncio.new_event_loop()
+    session = EESession(sepal_headers=dummy_headers)
+
+    # Bind to loop A and simulate active work (acquire a semaphore slot)
+    async def bind_and_hold():
+        session._ensure_bound()
+        await session._inflight.acquire()
+
+    loop_a.run_until_complete(bind_and_hold())
+    assert session._has_active_work()
+
+    # Try to use from loop B in another thread
+    error = None
+
+    def run_on_loop_b():
+        nonlocal error
+        loop_b = asyncio.new_event_loop()
+        try:
+
+            async def attempt_use():
+                session._ensure_bound()
+
+            loop_b.run_until_complete(attempt_use())
+        except EELoopError as e:
+            error = e
+        finally:
+            loop_b.close()
+
+    t = threading.Thread(target=run_on_loop_b)
+    t.start()
+    t.join()
+
+    assert error is not None
+    assert "active work" in str(error)
+
+    # Cleanup
+    loop_a.run_until_complete(_release_semaphore(session))
+    loop_a.close()
+
+
+async def _release_semaphore(session):
+    session._inflight.release()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Rebinding after previous loop is fully idle
+# ---------------------------------------------------------------------------
+
+
+def test_rebind_after_idle(dummy_headers):
+    """Rebind succeeds when old loop has no active work."""
+    loop_a = asyncio.new_event_loop()
+    session = EESession(sepal_headers=dummy_headers)
+
+    async def use_on_loop():
+        session._ensure_bound()
+
+    loop_a.run_until_complete(use_on_loop())
+    assert session._bound_loop is loop_a
+    assert not session._has_active_work()
+
+    # Rebind to loop B
+    loop_b = asyncio.new_event_loop()
+    loop_b.run_until_complete(use_on_loop())
+    assert session._bound_loop is loop_b
+
+    loop_a.close()
+    loop_b.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Wrong-loop aclose() behavior
+# ---------------------------------------------------------------------------
+
+
+def test_aclose_wrong_loop_raises(dummy_headers):
+    """aclose() from a different loop raises EELoopError; client is NOT closed."""
+    loop_a = asyncio.new_event_loop()
+    session = EESession(sepal_headers=dummy_headers)
+
+    async def bind_session():
+        session._ensure_bound()
+
+    loop_a.run_until_complete(bind_session())
+
+    # Try aclose from loop B
+    loop_b = asyncio.new_event_loop()
+    error = None
+
+    async def close_on_b():
+        nonlocal error
+        try:
+            await session.aclose()
+        except EELoopError as e:
+            error = e
+
+    loop_b.run_until_complete(close_on_b())
+
+    assert error is not None
+    assert "aclose()" in str(error)
+
+    loop_a.close()
+    loop_b.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Pending cache-task blocks rebinding
+# ---------------------------------------------------------------------------
+
+
+def test_pending_cache_task_blocks_rebind(dummy_headers):
+    """An in-flight cache task prevents rebinding to a new loop."""
+    loop_a = asyncio.new_event_loop()
+    session = EESession(sepal_headers=dummy_headers)
+
+    async def bind_and_add_pending_task():
+        session._ensure_bound()
+        # Insert a cache entry with an unresolved task
+        future = asyncio.get_running_loop().create_future()
+        task = asyncio.ensure_future(future)
+        session._assets_cache._cache["test_key"] = CacheEntry(task=task)
+
+    loop_a.run_until_complete(bind_and_add_pending_task())
+    assert session._assets_cache.has_pending_tasks()
+
+    # Try to rebind from loop B
+    loop_b = asyncio.new_event_loop()
+    error = None
+
+    async def try_rebind():
+        nonlocal error
+        try:
+            session._ensure_bound()
+        except EELoopError as e:
+            error = e
+
+    loop_b.run_until_complete(try_rebind())
+
+    assert error is not None
+    assert "active work" in str(error)
+
+    # Cleanup: resolve the future so the task completes
+    async def resolve():
+        for entry in session._assets_cache._cache.values():
+            if entry.task and not entry.task.done():
+                entry.task.cancel()
+                try:
+                    await entry.task
+                except asyncio.CancelledError:
+                    pass
+
+    loop_a.run_until_complete(resolve())
+    loop_a.close()
+    loop_b.close()


### PR DESCRIPTION
## Summary

Closes #14.

- **Lazy loop binding**: asyncio primitives (`BoundedSemaphore`, `Lock`, `httpx.AsyncClient`, `ResponseCache` lock) are no longer created in `__init__`. They are created on first async use via `_ensure_bound()`, binding the session to the running event loop.
- **Guarded rebind**: if the session is later used from a different loop, it rebinds only when no active work exists (no in-flight requests, no pending cache tasks, no open HTTP client). Otherwise raises `EELoopError`.
- **Wrong-loop `aclose()` rejection**: `aclose()` raises `EELoopError` if called from a different loop than the one the session is bound to, preventing silent resource leaks.

## Files changed

| File | Change |
|------|--------|
| `eeclient/exceptions.py` | Added `EELoopError(EEClientError)` |
| `eeclient/cache.py` | Lazy `_lock` init, `has_pending_tasks()`, `_rebind()` |
| `eeclient/client.py` | Deferred primitive creation, `_ensure_bound()`, `_has_active_work()`, `_bind()`, guarded async entry points, safe `aclose()` |
| `tests/test_loop_binding.py` | 5 new tests |

## Test plan

- [x] Normal same-loop use works
- [x] Concurrent second-loop use is rejected with `EELoopError`
- [x] Rebinding succeeds after previous loop is fully idle
- [x] Wrong-loop `aclose()` raises `EELoopError`
- [x] Pending cache tasks block rebinding
- [x] All 25 existing tests pass (zero regressions)
- [x] Pre-commit hooks pass (black, ruff, prettier, codespell, commitizen)