### PR TITLE
feat: accept legacy sepal_ui file_format aliases in DriveOptions

### DIFF
--- a/eeclient/export/image.py
+++ b/eeclient/export/image.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, Union
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from pydantic.alias_generators import to_camel
 
 if TYPE_CHECKING:
@@ -44,10 +44,22 @@ class EarthEngineDestination(BaseExportModel):
     name: str
 
 
+_IMAGE_FILE_FORMAT_ALIASES = {
+    "GeoTIFF": "GEO_TIFF",
+}
+
+
 class DriveOptions(BaseExportModel):
     # Removed default so that users must supply a file_format.
     file_format: ImageFileFormat
     drive_destination: DriveDestination
+
+    @field_validator("file_format", mode="before")
+    @classmethod
+    def _accept_legacy_aliases(cls, v):
+        if isinstance(v, str):
+            return _IMAGE_FILE_FORMAT_ALIASES.get(v, v)
+        return v
 
     # TODO: Add support for other export options
     # TODO: add support for format_options

--- a/eeclient/export/table.py
+++ b/eeclient/export/table.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Optional
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 from pydantic.alias_generators import to_camel
 
 if TYPE_CHECKING:
@@ -38,10 +38,23 @@ class EarthEngineDestination(BaseExportModel):
     name: str
 
 
+_TABLE_FILE_FORMAT_ALIASES = {
+    "GeoJSON": "GEO_JSON",
+    "Shapefile": "SHP",
+}
+
+
 class DriveOptions(BaseExportModel):
     # Removed default so that users must supply a file_format.
     file_format: TableFileFormat
     drive_destination: DriveDestination
+
+    @field_validator("file_format", mode="before")
+    @classmethod
+    def _accept_legacy_aliases(cls, v):
+        if isinstance(v, str):
+            return _TABLE_FILE_FORMAT_ALIASES.get(v, v)
+        return v
 
 
 class AssetOptions(BaseExportModel):

--- a/tests/test_export_image.py
+++ b/tests/test_export_image.py
@@ -1,0 +1,31 @@
+import pytest
+
+from eeclient.export.image import (
+    DriveDestination,
+    DriveOptions,
+    ImageFileFormat,
+)
+
+
+def test_drive_options_accepts_legacy_geotiff_alias():
+    opts = DriveOptions(
+        file_format="GeoTIFF",
+        drive_destination=DriveDestination(filename_prefix="out"),
+    )
+    assert opts.file_format == ImageFileFormat.GEO_TIFF
+
+
+def test_drive_options_accepts_canonical_value():
+    opts = DriveOptions(
+        file_format="GEO_TIFF",
+        drive_destination=DriveDestination(filename_prefix="out"),
+    )
+    assert opts.file_format == ImageFileFormat.GEO_TIFF
+
+
+def test_drive_options_rejects_unknown_string():
+    with pytest.raises(ValueError):
+        DriveOptions(
+            file_format="NotAFormat",
+            drive_destination=DriveDestination(filename_prefix="out"),
+        )

--- a/tests/test_export_table.py
+++ b/tests/test_export_table.py
@@ -42,6 +42,29 @@ def test_drive_export_options_serialize_as_file_export_options():
     assert "assetExportOptions" not in payload
 
 
+@pytest.mark.parametrize(
+    "alias,canonical",
+    [
+        ("GeoJSON", TableFileFormat.GEO_JSON),
+        ("Shapefile", TableFileFormat.SHP),
+    ],
+)
+def test_drive_options_accepts_legacy_table_aliases(alias, canonical):
+    opts = DriveOptions(
+        file_format=alias,
+        drive_destination=DriveDestination(filename_prefix="out"),
+    )
+    assert opts.file_format == canonical
+
+
+def test_drive_options_rejects_unknown_string():
+    with pytest.raises(ValueError):
+        DriveOptions(
+            file_format="NotAFormat",
+            drive_destination=DriveDestination(filename_prefix="out"),
+        )
+
+
 @pytest.mark.asyncio
 async def test_table_to_asset_async_sends_asset_export_options():
     client = AsyncMock()


### PR DESCRIPTION
## Summary

Closes #18.

`ImageFileFormat` / `TableFileFormat` are strict `str`-Enums, so passing a legacy sepal_ui-style name crashes with a pydantic `ValidationError`:

```python
DriveOptions(file_format="GeoTIFF", ...)
# → Input should be 'GEO_TIFF', 'JPEG', 'PNG', ...
```

This adds a `@field_validator(..., mode="before")` on `DriveOptions.file_format` in both `eeclient/export/image.py` and `eeclient/export/table.py` that maps known legacy aliases to their canonical enum values:

| Alias       | Canonical  | Module |
|-------------|------------|--------|
| `GeoTIFF`   | `GEO_TIFF` | image  |
| `GeoJSON`   | `GEO_JSON` | table  |
| `Shapefile` | `SHP`      | table  |

Callers already sending canonical values are unaffected — unknown strings still raise `ValidationError` as before.

`AssetOptions` is untouched in both modules because it has no `file_format` field (asset exports go to GEE directly).

## Test plan

- [x] `tests/test_export_image.py` — legacy alias, canonical value, and unknown-string rejection
- [x] `tests/test_export_table.py` — parametrized legacy aliases (`GeoJSON`, `Shapefile`) + unknown-string rejection
- [x] `pytest tests/test_export_image.py tests/test_export_table.py` — 9 passed
- [ ] Manual smoke test from a sepal_ui / pysepal caller passing the legacy spelling