### PR TITLE
fix(export): preserve clipped image from _apply_selection_and_scale

### DIFF
--- a/eeclient/export/image.py
+++ b/eeclient/export/image.py
@@ -185,7 +185,13 @@ async def _export_image(
     image, updated_image_params, dimensions_consumed = image._apply_crs_and_affine(
         image_params
     )
-    image._apply_selection_and_scale(updated_image_params, dimensions_consumed)
+    # _apply_selection_and_scale returns a new image wrapped in
+    # clipToBoundsAndScale(geometry=region); discarding the return value would
+    # serialize the original unbounded image and cause GEE to reject the task
+    # with "Unable to export unbounded image." (issue #20)
+    image, _ = image._apply_selection_and_scale(
+        updated_image_params, dimensions_consumed
+    )
 
     expression = serializer.encode(image, for_cloud_api=True)
     request_params["expression"] = expression

--- a/tests/test_export_image.py
+++ b/tests/test_export_image.py
@@ -1,9 +1,12 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from eeclient.export.image import (
     DriveDestination,
     DriveOptions,
     ImageFileFormat,
+    _export_image,
 )
 
 
@@ -29,3 +32,58 @@ def test_drive_options_rejects_unknown_string():
             file_format="NotAFormat",
             drive_destination=DriveDestination(filename_prefix="out"),
         )
+
+
+@pytest.mark.asyncio
+async def test_export_image_uses_clipped_image_from_selection_and_scale():
+    """Regression test for issue #20.
+
+    `ee.Image._apply_selection_and_scale` returns a new image wrapped in
+    `clipToBoundsAndScale(geometry=region)`. The export flow must serialize
+    that clipped image, not the original, or GEE rejects the task as
+    "Unable to export unbounded image".
+    """
+    original_image = MagicMock(name="original_image")
+    crs_applied_image = MagicMock(name="crs_applied_image")
+    clipped_image = MagicMock(name="clipped_image")
+
+    original_image._apply_crs_and_affine.return_value = (
+        crs_applied_image,
+        {"region": "geom", "scale": 30},
+        False,
+    )
+    crs_applied_image._apply_selection_and_scale.return_value = (
+        clipped_image,
+        {},
+    )
+
+    client = MagicMock()
+    client.rest_call = AsyncMock(
+        return_value={"name": "projects/p/operations/op", "metadata": {}}
+    )
+
+    drive_options = DriveOptions(
+        file_format=ImageFileFormat.GEO_TIFF,
+        drive_destination=DriveDestination(filename_prefix="out"),
+    )
+
+    with (
+        patch("eeclient.export.image.serializer.encode") as mock_encode,
+        patch("eeclient.export.image.Task.model_validate") as mock_validate,
+    ):
+        mock_encode.return_value = {"result": "encoded"}
+        mock_validate.return_value = MagicMock()
+
+        await _export_image(
+            client=client,
+            image=original_image,
+            drive_options=drive_options,
+            region="geom",
+            scale=30,
+        )
+
+    # The serialized expression must be the clipped image, not the original
+    # or the intermediate crs-applied image.
+    mock_encode.assert_called_once()
+    encoded_image = mock_encode.call_args.args[0]
+    assert encoded_image is clipped_image


### PR DESCRIPTION
Fixes #20

## Root cause

`ee.Image._apply_selection_and_scale` returns a tuple of `(clipped_image, remaining_params)`, where the clipped image is wrapped in `clipToBoundsAndScale(geometry=region)`. `_export_image` was discarding that return value and serializing the original unbounded image, so GEE rejected every session-backed export with "Unable to export unbounded image. (Error code: 3)" even when a valid `region` was provided.

## Change

- Capture the returned image and forward it to `serializer.encode`.
- Add a regression unit test asserting the clipped image (not the original) is the one passed to `serializer.encode`.