### PR TITLE
fix(tasks): make Stage work-unit fields optional

### DIFF
--- a/eeclient/tasks.py
+++ b/eeclient/tasks.py
@@ -24,9 +24,12 @@ class CamelCaseModel(BaseModel):
 
 class Stage(CamelCaseModel):
     display_name: str
-    complete_work_units: int
-    total_work_units: str
-    description: str
+    # The Cloud API omits these fields on a stage until that stage has
+    # reported progress, so they must be optional to avoid breaking polling
+    # of a freshly-RUNNING task.
+    complete_work_units: Optional[int] = None
+    total_work_units: Optional[str] = None
+    description: Optional[str] = None
 
 
 class TaskMetadata(CamelCaseModel):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,60 @@
+"""Tests for the Task / Stage models in eeclient.tasks."""
+
+from eeclient.tasks import Stage, Task
+
+
+def test_stage_allows_missing_work_units():
+    """The Cloud API omits completeWorkUnits/totalWorkUnits on a stage until
+    that stage reports progress; the model must accept this."""
+    stage = Stage.model_validate(
+        {
+            "displayName": "Create List of Assets",
+            "description": "Listing of temporary files.",
+        }
+    )
+    assert stage.display_name == "Create List of Assets"
+    assert stage.complete_work_units is None
+    assert stage.total_work_units is None
+
+
+def test_stage_allows_missing_description():
+    """Some stages omit `description` entirely before reporting progress."""
+    stage = Stage.model_validate({"displayName": "Write Files"})
+    assert stage.display_name == "Write Files"
+    assert stage.description is None
+    assert stage.complete_work_units is None
+    assert stage.total_work_units is None
+
+
+def test_task_validates_with_incomplete_stages():
+    """Regression for issue #22: polling a freshly-RUNNING export returns
+    stages without completeWorkUnits / totalWorkUnits and must not raise."""
+    payload = {
+        "name": "projects/ee-project/operations/ABC123",
+        "metadata": {
+            "@type": "type.googleapis.com/google.earthengine.v1.OperationMetadata",
+            "state": "RUNNING",
+            "description": "my-export",
+            "priority": 100,
+            "createTime": "2026-05-13T12:00:00Z",
+            "type": "EXPORT_IMAGE",
+            "stages": [
+                {
+                    "displayName": "Create List of Assets",
+                    "description": "Listing of temporary files.",
+                },
+                {
+                    "displayName": "Write Files",
+                    "description": "Writing files to the export destination.",
+                },
+            ],
+        },
+        "done": False,
+    }
+
+    task = Task.model_validate(payload)
+    assert task.id == "ABC123"
+    assert task.metadata.stages is not None
+    assert len(task.metadata.stages) == 2
+    assert task.metadata.stages[0].complete_work_units is None
+    assert task.metadata.stages[0].total_work_units is None


### PR DESCRIPTION
Fixes #22

## Root cause

The Cloud API omits `completeWorkUnits`, `totalWorkUnits`, and sometimes `description` on a stage until that stage has reported progress. `Stage` in `eeclient/tasks.py` declared `complete_work_units: int`, `total_work_units: str`, and `description: str` as required, so the first poll of a freshly-RUNNING export via `get_task_async` / `get_tasks_async` raised `pydantic.ValidationError`, breaking every export-polling caller.

## Changes

- `eeclient/tasks.py`: `Stage.complete_work_units`, `total_work_units`, and `description` are now `Optional` with a `None` default.
- `tests/test_tasks.py`: new regression tests validating a `Stage` and full `Task` payload with stages missing those fields.