### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       #- uses: ./.github/workflows/unit.yaml
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
       - name: Install dependencies

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,10 +15,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -34,8 +34,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
           cache: pip


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to immutable commit SHAs instead of mutable tags. Prevents supply-chain attacks where an upstream tag is rewritten or the maintainer's account is compromised.

## Pinned actions

- \`actions/checkout\` v3/v4 -> \`34e114876b0b11c390a56381ad16ebd13914f8d5\` (v4)
- \`actions/setup-python\` v4/v5 -> \`a26af69be951a213d495a4c3e4e4022e16d87065\` (v5)

Each pin is a version bump where the previous ref was older than v4/v5.

## Test plan

- [x] \`tests.yaml\` runs green on this PR
- [x] \`release.yaml\` will be exercised on the next release; no functional change beyond the pinned SHAs.