### PR TITLE
ci: switch PyPI release to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # OIDC for trusted publishing to PyPI
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -15,12 +18,13 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-      - name: Install dependencies
-        run: pip install twine build nox
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python -m build
-          twine upload dist/*
+
+      - name: Install build tooling
+        run: pip install build
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        # Auth via OIDC trusted publisher; no PYPI_PASSWORD needed.


### PR DESCRIPTION
## Summary

Replace the long-lived \`PYPI_PASSWORD\` secret with PyPI's OIDC trusted publisher flow via \`pypa/gh-action-pypi-publish\`. Publishing now happens through a short-lived token minted at release time, scoped to this repo + workflow + environment.

The deploy job runs in the \`pypi\` GitHub Environment (which PyPI's trusted publisher matches against) and requires \`id-token: write\`.

(Originally bundled with PR #24 but landed after that PR merged; extracted into its own PR.)

## Prerequisites already met

- Trusted publisher already configured on PyPI for \`ee-client\`
- \`pypi\` GitHub Environment already exists in this repo

## Cleanup after merge

Once the next release verifies OIDC publishing works, delete the \`PYPI_PASSWORD\` secret from this repo's settings.