### PR TITLE
ci: trigger release on 'published' instead of 'created'

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Upload Python Package
 on:
   workflow_dispatch:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

Align this repo's release trigger with pysepal and pysepal-api: `release: types: [created]` -> `[published]`. Draft releases no longer fire the publish workflow.

`workflow_dispatch` was already present, so manual retrigger is unchanged.

No other changes; OIDC publishing is unchanged.