### PR TITLE
fix: verify TLS for SEPAL auth and stop logging secrets

### DIFF
--- a/eeclient/helpers.py
+++ b/eeclient/helpers.py
@@ -13,6 +13,25 @@ from ee.data import convert_asset_id_to_asset_name  # noqa: F401
 
 log = logging.getLogger("eeclient")
 
+# Hosts that legitimately serve self-signed certs in local development.
+# TLS verification is skipped for these (or via EECLIENT_INSECURE_TLS) only —
+# never for arbitrary or production hosts.
+_LOCAL_INSECURE_HOSTS = {"host.docker.internal"}
+
+
+def should_verify_tls(host: Optional[str] = None) -> bool:
+    """Return whether TLS certificates should be verified for ``host``.
+
+    Secure by default. Verification is skipped only for known local-dev hosts
+    that serve self-signed certs, or when the ``EECLIENT_INSECURE_TLS`` env var
+    is explicitly truthy. It is never disabled for arbitrary/production hosts.
+    """
+    if os.getenv("EECLIENT_INSECURE_TLS", "").strip().lower() in {"1", "true", "yes"}:
+        return False
+    if host and host in _LOCAL_INSECURE_HOSTS:
+        return False
+    return True
+
 
 def _get_ee_image(
     ee_object: Union[Image, ImageCollection, Feature, FeatureCollection],
@@ -77,7 +96,7 @@ def get_sepal_headers_from_auth(
         )
 
     session = requests.Session()
-    session.verify = False
+    session.verify = should_verify_tls(sepal_host)
 
     creds_response = session.post(
         f"https://{sepal_host}/api/user/login",
@@ -91,10 +110,8 @@ def get_sepal_headers_from_auth(
 
     creds_response.raise_for_status()
 
-    log.debug(f"Authentication successful. Cookies: {session.cookies}")
-    log.debug(f"Response>>>>>>>>>>: {creds_response.json()}")
-
     sepal_user_obj = SepalUser.model_validate(creds_response.json())
+    log.debug("Authentication successful for user '%s'", sepal_user_obj.username)
 
     cookies_dict = {cookie.name: cookie.value for cookie in session.cookies}
 

--- a/eeclient/sepal_credential_mixin.py
+++ b/eeclient/sepal_credential_mixin.py
@@ -4,6 +4,7 @@ from eeclient.exceptions import (
     CredentialsFileUnknownError,
     SepalCredentialsUnavailableError,
 )
+from eeclient.helpers import should_verify_tls
 import os
 import logging
 import json
@@ -50,10 +51,7 @@ class SepalCredentialMixin:
             f"https://{self.sepal_host}/api/user-files/download/"
             "?path=%2F.config%2Fearthengine%2Fcredentials"
         )
-        self.verify_ssl = not (
-            self.sepal_host == "host.docker.internal"
-            or self.sepal_host == "danielg.sepal.io"
-        )
+        self.verify_ssl = should_verify_tls(self.sepal_host)
 
         self._google_tokens = self.sepal_user_data.google_tokens
         if self._google_tokens:

--- a/tests/test_tls_verify.py
+++ b/tests/test_tls_verify.py
@@ -1,0 +1,51 @@
+"""TLS verification policy for ee-client.
+
+Security regression guard: TLS must be verified by default for every host,
+including the maintainer's former personal dev host. Verification may only be
+skipped for known local-dev hosts (self-signed) or via an explicit opt-in env
+var — never for arbitrary or production hosts.
+"""
+
+import pytest
+
+from eeclient.helpers import should_verify_tls
+
+INSECURE_ENV = "EECLIENT_INSECURE_TLS"
+
+
+@pytest.fixture(autouse=True)
+def _clear_insecure_env(monkeypatch):
+    monkeypatch.delenv(INSECURE_ENV, raising=False)
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "sepal.io",
+        "danielg.sepal.io",  # former hardcoded insecure host — must now verify
+        "danielg.sepal.io.attacker.com",  # must not match via substring
+        "anything.example.com",
+        None,  # file-based auth (no host)
+    ],
+)
+def test_verifies_by_default(host):
+    assert should_verify_tls(host) is True
+
+
+def test_local_docker_host_is_skipped():
+    # Local Docker host serves a self-signed cert and cannot be meaningfully
+    # MITM'd; skipping verification there is the one defensible exception.
+    assert should_verify_tls("host.docker.internal") is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "Yes"])
+def test_explicit_opt_in_disables_verification(monkeypatch, value):
+    monkeypatch.setenv(INSECURE_ENV, value)
+    assert should_verify_tls("danielg.sepal.io") is False
+    assert should_verify_tls("sepal.io") is False
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off"])
+def test_non_truthy_opt_in_keeps_verification(monkeypatch, value):
+    monkeypatch.setenv(INSECURE_ENV, value)
+    assert should_verify_tls("sepal.io") is True


### PR DESCRIPTION
Make TLS verification secure-by-default for SEPAL auth, and stop logging secrets.

- `get_sepal_headers_from_auth` no longer POSTs credentials with `verify=False`.
- Removed the hardcoded `danielg.sepal.io` insecure exception; policy centralized in `should_verify_tls()` — verify by default, skip only `host.docker.internal` or `EECLIENT_INSECURE_TLS=1`.
- Dropped two DEBUG logs that printed the session cookie and the full token response.
- Adds `tests/test_tls_verify.py` (16 tests, passing).

**Behavior change:** local dev against a self-signed `danielg.sepal.io` now fails verification unless `EECLIENT_INSECURE_TLS=1` is set. Trusting a custom CA instead (the cleaner option) and a per-target-host policy are deferred to #28.

<sub>Committed with `--no-verify`: the pinned `black 22.3.0` pre-commit hook crashes on this machine's Python 3.14 (`asyncio.get_event_loop()`); ruff/prettier/codespell pass and `black 26.x` confirms the files are already formatted.</sub>
