### PR TITLE
feat: refuse a service-account EE credentials file unless opted in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## Unreleased
+
+### Behavior changes
+
+Not breaking, but worth reading before you upgrade. Both entries below change
+_when_ and _which_ exception fires for a credentials file that never worked: an
+Earth Engine credentials file without a usable refresh token has never resolved
+to a refreshable credential, in this library or in `earthengine-api` itself
+(`ee.data.get_persistent_credentials()` gates on `refresh_token` and otherwise
+falls through to ADC). No working configuration is affected, and both new errors
+subclass `CredentialsResolutionError`, which these paths did not raise before —
+so `except CredentialsResolutionError` now catches strictly more than it did.
+
+One operational note: the failure moves from first token refresh to session
+construction. A long-running service that builds its session at import and
+currently starts up before failing on the first request will now fail at
+startup instead.
+
+- A service-account-shaped file at the Earth Engine credentials path
+  (`~/.config/earthengine/credentials`) is now **refused** by
+  `resolve_default_provider()` / `EESession.from_default()`, raising
+  `ServiceAccountFileRefusedError`. That path is a machine-wide identity;
+  resolving it implicitly hands every caller on the host the same Earth Engine
+  account. Pass `allow_service_account_file=True` to opt in, or use
+  `EESession.from_service_account()` directly.
+
+  Previously such a file produced an OAuth credential with `refresh_token=None`:
+  `from_default()` returned, and the failure surfaced later as a
+  `google.auth.exceptions.RefreshError` on `initialize()` / the first
+  `get_headers()`. It now fails at construction with an actionable message, and
+  the opt-in makes the file usable for the first time. Nothing to migrate unless
+  you caught `RefreshError` around that first call.
+
+  In a SEPAL context (`sepal-user` home) resolution is SEPAL-file-only, so this
+  guard does not apply there.
+
+- A credentials file that is unparsable, is not a JSON object, or carries no
+  `refresh_token` now raises `CredentialsFileUnrecognizedError` from
+  `resolve_default_provider()` instead of falling through to the OAuth loader.
+  Same shape of change: the error moves from first refresh to construction.
+
+  A file that exists but cannot be read (permissions) raises
+  `CredentialsResolutionError` chaining the original `OSError`, rather than
+  being reported as a malformed credential.
+
+### Features
+
+- `session.auth_source` gains `ee_service_account_file` for a service-account
+  key resolved from the Earth Engine credentials path via the new opt-in.
+- `CredentialMixin.close()` releases the sync `_service` handle if one is
+  attached. `EESession.aclose()` now calls it, so `await session.aclose()` is
+  the complete teardown.
+- New `CredentialsFileUnrecognizedError`, a `CredentialsResolutionError`
+  subclass carrying the offending path. Every failure mode of
+  `EESession.from_default()` is now catchable as `CredentialsResolutionError`;
+  the SEPAL-specific `CredentialsFileUnknownError` is no longer raised from the
+  provider-agnostic path.
+
 ## 3.0.0
 
 ### Breaking changes

--- a/README.rst
+++ b/README.rst
@@ -81,11 +81,19 @@ A session can be built from any standard Google/Earth Engine credential via fact
 Credentials are **never resolved implicitly** — a bare ``EESession()`` constructor call is not supported; always use a ``from_*`` factory to build a session. To resolve from the environment explicitly, call ``EESession.from_default()``, which walks local sources only, in this order:
 
 1. ``EARTHENGINE_TOKEN`` environment variable
-2. Earth Engine OAuth file (``~/.config/earthengine/credentials``)
+2. Earth Engine credentials file (``~/.config/earthengine/credentials``)
+
+The credentials file is accepted only when it holds an OAuth refresh token — the file ``earthengine authenticate`` writes. A **service-account key** at that path is refused with ``ServiceAccountFileRefusedError``: it is a machine-wide identity, so resolving it implicitly would give every caller on the host the same Earth Engine account. To use it anyway, opt in explicitly:
+
+.. code-block:: python
+
+   session = EESession.from_default(allow_service_account_file=True)
+
+Prefer ``EESession.from_service_account("sa-key.json")``, which names the key you mean. Any other file shape — unparsable, or without a refresh token — raises ``CredentialsFileUnrecognizedError``. Both errors subclass ``CredentialsResolutionError``, so a single ``except`` covers every way ``from_default()`` can fail to resolve.
 
 Application Default Credentials are **not** included — call ``EESession.from_application_default()`` to use them.
 
-To see which source a session ended up using, inspect ``session.auth_mode`` (the credential *kind*: ``file``/``oauth``/``service_account``/``adc``) and ``session.auth_source`` (the precise origin: ``earthengine_token``/``ee_oauth_file``/``service_account``/``application_default``/``google_credentials``).
+To see which source a session ended up using, inspect ``session.auth_mode`` (the credential *kind*: ``file``/``oauth``/``service_account``/``adc``/``sepal``) and ``session.auth_source`` (the precise origin: ``earthengine_token``/``ee_oauth_file``/``ee_service_account_file``/``service_account``/``application_default``/``google_credentials``/``sepal_file``/``sepal_session``).
 
 Making API Calls
 ++++++++++++++++

--- a/eeclient/client.py
+++ b/eeclient/client.py
@@ -219,7 +219,9 @@ class EESession(CredentialMixin):
         return cls(headers, enforce_project_id=enforce_project_id)
 
     @classmethod
-    def from_default(cls, *, enforce_project_id=True) -> "EESession":
+    def from_default(
+        cls, *, enforce_project_id=True, allow_service_account_file=False
+    ) -> "EESession":
         """Resolve credentials from the environment — explicit opt-in.
 
         Walks local sources only (SEPAL file, ``EARTHENGINE_TOKEN``, Earth Engine
@@ -227,13 +229,18 @@ class EESession(CredentialMixin):
         use ``from_application_default()``. This is opt-in: a bare ``EESession()``
         does not auto-resolve; the caller must pick a source.
 
+        ``allow_service_account_file`` opts in to a service-account key at the
+        Earth Engine credentials path; refused by default (a shared identity).
+
         Construction does no network I/O — the token refresh is deferred to
         ``await initialize()`` / the first ``get_headers()`` so async callers are
         not blocked (use ``set_credentials_sync()`` for a synchronous refresh).
         """
         from eeclient.providers import resolve_default_provider
 
-        provider = resolve_default_provider()
+        provider = resolve_default_provider(
+            allow_service_account_file=allow_service_account_file
+        )
         return cls(enforce_project_id=enforce_project_id, _provider=provider)
 
     async def get_assets_folder(self) -> str:

--- a/eeclient/client.py
+++ b/eeclient/client.py
@@ -291,10 +291,15 @@ class EESession(CredentialMixin):
         yield client
 
     async def aclose(self):
+        """Full teardown: the async transport plus any sync resources.
+
+        Must run on the loop that created the ``httpx.AsyncClient``.
+        """
         if self._client is not None:
             await self._client.aclose()
             self._client = None
         self._assets_cache.clear()
+        self.close()
 
     async def rest_call(
         self,

--- a/eeclient/credential_mixin.py
+++ b/eeclient/credential_mixin.py
@@ -92,6 +92,26 @@ class CredentialMixin:
         """Refresh credentials via the active provider (sync)."""
         self._apply_snapshot(self._provider.refresh_sync())
 
+    def close(self) -> None:
+        """Release the synchronous resources this credential holder owns.
+
+        Closes ``self._service`` — a ``googleapiclient`` discovery service, which
+        holds an ``httplib2`` connection — when one is attached. Nothing in this
+        library builds that service; ``_service`` is a backward-compat attribute
+        that callers may assign themselves, so on a stock session this is a
+        no-op. Idempotent.
+
+        This does **not** close an async transport. :class:`eeclient.client.EESession`
+        owns an ``httpx.AsyncClient`` that must be closed with ``await aclose()``
+        on the loop that created it — and ``aclose()`` calls this method, so
+        ``await session.aclose()`` is the complete teardown. Reaching for
+        ``contextlib.closing(session)`` instead would leave the transport open.
+        """
+        service = self._service
+        self._service = None
+        if service is not None:
+            service.close()
+
 
 # Backward-compat alias: SEPAL is now one provider among several.
 SepalCredentialMixin = CredentialMixin

--- a/eeclient/exceptions.py
+++ b/eeclient/exceptions.py
@@ -99,6 +99,43 @@ class CredentialsResolutionError(EEClientError):
         super().__init__(message)
 
 
+class CredentialsFileUnrecognizedError(CredentialsResolutionError):
+    """Raised when the EE credentials file is not a shape we can build from.
+
+    Distinct from :class:`CredentialsFileUnknownError`, which is SEPAL-specific:
+    this one is raised from provider-agnostic resolution and carries the path
+    instead of SEPAL re-authentication instructions.
+    """
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        super().__init__(
+            f"{file_path} is not a usable Earth Engine credentials file: it is "
+            "not JSON, not a JSON object, or carries no refresh token. Run "
+            "`earthengine authenticate` to rewrite it, or pick an explicit "
+            "source with one of the EESession.from_*() factories."
+        )
+
+
+class ServiceAccountFileRefusedError(CredentialsResolutionError):
+    """Raised when the EE credentials file holds a service-account key.
+
+    A service-account key at ``~/.config/earthengine/credentials`` is a shared,
+    machine-wide identity. Resolving it implicitly would give every caller in a
+    multi-user container the same Earth Engine identity, so it is refused unless
+    the caller opts in.
+    """
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        super().__init__(
+            f"{file_path} holds a service-account key. Resolving it implicitly "
+            "would share one Earth Engine identity across every caller in this "
+            "process. Pass allow_service_account_file=True to opt in, or use "
+            "EESession.from_service_account()."
+        )
+
+
 # {'code': 401, 'message': 'Request had invalid authentication credentials.
 # Expected OAuth 2 access token, login cookie or other valid authentication
 # credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.',

--- a/eeclient/providers.py
+++ b/eeclient/providers.py
@@ -21,9 +21,11 @@ from ee import oauth as ee_oauth
 from eeclient.exceptions import (
     CredentialsFileNotFoundError,
     CredentialsFileUnknownError,
+    CredentialsFileUnrecognizedError,
     CredentialsResolutionError,
     EEClientError,
     SepalCredentialsUnavailableError,
+    ServiceAccountFileRefusedError,
 )
 from eeclient.helpers import should_verify_tls
 from eeclient.models import GoogleTokens, SepalHeaders
@@ -374,11 +376,46 @@ def _is_sepal_context() -> bool:
     return "sepal-user" in Path.home().name
 
 
-def resolve_default_provider() -> CredentialProvider:
+def _classify_credentials_file(path: Path) -> str:
+    """Classify an Earth Engine credentials file without building credentials.
+
+    Returns ``"service_account"``, ``"oauth"`` or ``"unknown"``. Reads the file;
+    never contacts a network or a token endpoint. An unreadable file raises
+    rather than classifying as ``"unknown"`` — a permission error on a file that
+    exists is an environment problem, not a malformed credential.
+    """
+    try:
+        raw = path.read_text()
+    except OSError as e:
+        raise CredentialsResolutionError(
+            f"Cannot read the Earth Engine credentials file {path}: {e}"
+        ) from e
+    except ValueError:
+        return "unknown"  # not UTF-8; read_text() raises UnicodeDecodeError
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return "unknown"
+    if not isinstance(data, dict):
+        return "unknown"
+    if data.get("type") == "service_account":
+        return "service_account"
+    if data.get("refresh_token"):
+        return "oauth"
+    return "unknown"
+
+
+def resolve_default_provider(
+    *, allow_service_account_file: bool = False
+) -> CredentialProvider:
     """Resolve a provider for a headerless ``EESession()`` — all-local, no ADC.
 
     In a SEPAL context (``sepal-user`` home) this is SEPAL-file-only and fails
     closed. Otherwise it walks local sources; ADC is never probed here (D10).
+
+    ``allow_service_account_file`` opts in to a service-account key at the
+    Earth Engine credentials path; it is refused by default because that
+    identity is shared by every caller in the process.
     """
     ee_dir = Path.home() / ".config" / "earthengine"
 
@@ -404,8 +441,23 @@ def resolve_default_provider() -> CredentialProvider:
             auth_source="earthengine_token",
         )
 
-    ee_file = ee_dir / "credentials"
+    # Resolve through ee.oauth so the file we classify is the file the OAuth
+    # loader will read — the two must not be able to disagree.
+    ee_file = Path(ee_oauth.get_credentials_path())
     if ee_file.exists():
+        kind = _classify_credentials_file(ee_file)
+        if kind == "service_account":
+            if not allow_service_account_file:
+                raise ServiceAccountFileRefusedError(str(ee_file))
+            creds, project = _service_account_credentials(ee_file, DEFAULT_SCOPES)
+            return GoogleAuthProvider(
+                creds,
+                project,
+                auth_mode="service_account",
+                auth_source="ee_service_account_file",
+            )
+        if kind == "unknown":
+            raise CredentialsFileUnrecognizedError(str(ee_file))
         creds, project = _oauth_credentials_from_ee_file(DEFAULT_SCOPES)
         return GoogleAuthProvider(
             creds, project, auth_mode="oauth", auth_source="ee_oauth_file"
@@ -413,7 +465,7 @@ def resolve_default_provider() -> CredentialProvider:
 
     raise CredentialsResolutionError(
         "No local credential source found (tried EARTHENGINE_TOKEN and the "
-        f"Earth Engine OAuth file {ee_file}). ADC is not used implicitly — call "
+        f"Earth Engine credentials file {ee_file}). ADC is not used implicitly — call "
         "EESession.from_application_default() to use Application Default "
         "Credentials."
     )

--- a/tests/test_credential_mixin_close.py
+++ b/tests/test_credential_mixin_close.py
@@ -1,0 +1,81 @@
+import pytest
+
+from eeclient.client import EESession
+from eeclient.credential_mixin import CredentialMixin
+
+
+class _StubProvider:
+    """Minimal CredentialProvider: no snapshot, no network."""
+
+    auth_mode = "stub"
+    auth_source = "stub"
+    user = "tester"
+    verify_ssl = True
+
+    def initial_snapshot(self):
+        return None
+
+    def refresh_sync(self):
+        raise AssertionError("refresh must not be called by close()")
+
+    async def refresh(self):
+        raise AssertionError("refresh must not be called by close()")
+
+
+class _SpyService:
+    def __init__(self):
+        self.closed = 0
+
+    def close(self):
+        self.closed += 1
+
+
+def test_close_closes_the_service_and_drops_the_reference():
+    holder = CredentialMixin(provider=_StubProvider())
+    service = _SpyService()
+    holder._service = service
+
+    holder.close()
+
+    assert service.closed == 1
+    assert holder._service is None
+
+
+def test_close_is_idempotent():
+    holder = CredentialMixin(provider=_StubProvider())
+    service = _SpyService()
+    holder._service = service
+
+    holder.close()
+    holder.close()
+
+    assert service.closed == 1
+
+
+def test_close_without_a_service_is_a_no_op():
+    CredentialMixin(provider=_StubProvider()).close()  # must not raise
+
+
+def test_close_does_not_touch_an_async_transport():
+    """EESession inherits close(); its httpx client still needs `await aclose()`."""
+    session = EESession(_provider=_StubProvider())
+    sentinel = object()
+    session._client = sentinel
+
+    session.close()
+
+    assert session._client is sentinel
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_the_complete_teardown():
+    """aclose() must also release the sync side, or it leaks what close() owns."""
+    session = EESession(_provider=_StubProvider())
+    service = _SpyService()
+    session._service = service
+
+    await session.aclose()
+
+    assert service.closed == 1
+    assert session._service is None
+    assert session._client is None

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -10,8 +10,15 @@ from eeclient.providers import GoogleAuthProvider, resolve_default_provider
 
 @pytest.fixture
 def home(tmp_path, monkeypatch):
-    """A non-SEPAL home with an empty ~/.config/earthengine and no token."""
+    """A non-SEPAL home with an empty ~/.config/earthengine and no token.
+
+    Two knobs, because resolution uses two: ``$HOME`` drives
+    ``ee.oauth.get_credentials_path()`` (via ``os.path.expanduser``), which is
+    the file that gets classified and loaded; ``Path.home()`` drives the SEPAL
+    context check. Patch only one and a test silently reads the real home.
+    """
     monkeypatch.setattr("eeclient.providers.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
     (tmp_path / ".config/earthengine").mkdir(parents=True)
     monkeypatch.delenv("EARTHENGINE_TOKEN", raising=False)
     return tmp_path
@@ -92,3 +99,147 @@ def test_from_default_auth_source_is_earthengine_token(home, monkeypatch):
         "EARTHENGINE_TOKEN", json.dumps({"refresh_token": "rt", "project": "p"})
     )
     assert resolve_default_provider().auth_source == "earthengine_token"
+
+
+def _write_credentials(home, payload: dict) -> Path:
+    path = home / ".config/earthengine/credentials"
+    path.write_text(json.dumps(payload))
+    return path
+
+
+class _ResolverStub:
+    auth_mode = "stub"
+    auth_source = "stub"
+    user = "tester"
+    verify_ssl = True
+
+    def initial_snapshot(self):
+        return None
+
+    def refresh_sync(self):
+        raise AssertionError("not used")
+
+    async def refresh(self):
+        raise AssertionError("not used")
+
+
+def test_service_account_credentials_file_is_refused_by_default(home):
+    from eeclient.exceptions import ServiceAccountFileRefusedError
+
+    _write_credentials(home, {"type": "service_account", "project_id": "p"})
+    with mock.patch("eeclient.providers._service_account_credentials") as sa:
+        with pytest.raises(ServiceAccountFileRefusedError) as e:
+            resolve_default_provider()
+    sa.assert_not_called()
+    assert "allow_service_account_file" in str(e.value)
+
+
+def test_service_account_file_wins_classification_over_a_refresh_token(home):
+    # A file carrying both markers must still be classified/refused as SA —
+    # the type check must run before the refresh_token check, not after.
+    from eeclient.exceptions import ServiceAccountFileRefusedError
+
+    _write_credentials(
+        home, {"type": "service_account", "project_id": "p", "refresh_token": "rt"}
+    )
+    with mock.patch("eeclient.providers._service_account_credentials") as sa:
+        with pytest.raises(ServiceAccountFileRefusedError):
+            resolve_default_provider()
+    sa.assert_not_called()
+
+
+def test_service_account_credentials_file_opt_in_builds_that_provider(home):
+    _write_credentials(home, {"type": "service_account", "project_id": "p"})
+    with mock.patch(
+        "eeclient.providers._service_account_credentials",
+        return_value=(object(), "p"),
+    ):
+        prov = resolve_default_provider(allow_service_account_file=True)
+    assert isinstance(prov, GoogleAuthProvider)
+    assert prov.auth_mode == "service_account"
+    assert prov.auth_source == "ee_service_account_file"
+
+
+def test_unparsable_credentials_file_raises_unrecognized(home):
+    from eeclient.exceptions import CredentialsFileUnrecognizedError
+
+    (home / ".config/earthengine/credentials").write_text("not json at all")
+    with pytest.raises(CredentialsFileUnrecognizedError):
+        resolve_default_provider()
+
+
+def test_binary_credentials_file_raises_unrecognized(home):
+    # Not valid UTF-8, so read_text() raises UnicodeDecodeError (a ValueError,
+    # not a JSONDecodeError) — must still classify as "unknown", not escape.
+    from eeclient.exceptions import CredentialsFileUnrecognizedError
+
+    (home / ".config/earthengine/credentials").write_bytes(b"\xff\xfe\x00\x01\x80")
+    with pytest.raises(CredentialsFileUnrecognizedError):
+        resolve_default_provider()
+
+
+def test_credentials_file_without_refresh_token_raises_unrecognized(home):
+    from eeclient.exceptions import CredentialsFileUnrecognizedError
+
+    _write_credentials(home, {"client_id": "cid"})
+    with pytest.raises(CredentialsFileUnrecognizedError):
+        resolve_default_provider()
+
+
+def test_unrecognized_file_error_is_a_resolution_error_and_names_the_path(home):
+    # `except CredentialsResolutionError` around from_default() must cover every
+    # way resolution can fail, and the message must not mention SEPAL.
+    from eeclient.exceptions import (
+        CredentialsFileUnrecognizedError,
+        CredentialsResolutionError,
+    )
+
+    path = _write_credentials(home, {"client_id": "cid"})
+    assert issubclass(CredentialsFileUnrecognizedError, CredentialsResolutionError)
+    with pytest.raises(CredentialsResolutionError) as e:
+        resolve_default_provider()
+    assert str(path) in str(e.value)
+    assert "SEPAL" not in str(e.value)
+
+
+def test_unreadable_credentials_file_surfaces_the_os_error(home):
+    # A file that exists but cannot be read is an environment problem, not a
+    # malformed credential — don't launder PermissionError into "unrecognized".
+    from eeclient.exceptions import (
+        CredentialsFileUnrecognizedError,
+        CredentialsResolutionError,
+    )
+
+    path = _write_credentials(home, {"refresh_token": "rt"})
+    denied = PermissionError(13, "Permission denied")
+    with mock.patch.object(Path, "read_text", side_effect=denied):
+        with pytest.raises(CredentialsResolutionError) as e:
+            resolve_default_provider()
+    assert not isinstance(e.value, CredentialsFileUnrecognizedError)
+    assert isinstance(e.value.__cause__, PermissionError)
+    assert str(path) in str(e.value)
+
+
+def test_oauth_credentials_file_still_resolves(home):
+    _write_credentials(home, {"refresh_token": "rt", "project": "p"})
+    prov = resolve_default_provider()
+    assert isinstance(prov, GoogleAuthProvider)
+    assert prov.auth_source == "ee_oauth_file"
+
+
+def test_from_default_forwards_the_service_account_opt_in():
+    from eeclient.client import EESession
+
+    with mock.patch("eeclient.providers.resolve_default_provider") as resolver:
+        resolver.return_value = _ResolverStub()
+        EESession.from_default(allow_service_account_file=True)
+    assert resolver.call_args.kwargs == {"allow_service_account_file": True}
+
+
+def test_from_default_refuses_a_service_account_file_by_default(home):
+    from eeclient.client import EESession
+    from eeclient.exceptions import ServiceAccountFileRefusedError
+
+    _write_credentials(home, {"type": "service_account", "project_id": "p"})
+    with pytest.raises(ServiceAccountFileRefusedError):
+        EESession.from_default()


### PR DESCRIPTION
`EESession.from_default()` now refuses a service-account key at `~/.config/earthengine/credentials`, raising `ServiceAccountFileRefusedError`. That path is a machine-wide identity, so resolving it implicitly hands every caller on the host the same Earth Engine account. Pass `allow_service_account_file=True` to opt in, or use `from_service_account()`.

**Not a breaking change**, despite changing what `from_default()` does with that file. It never resolved to a working credential: it produced an OAuth credential with `refresh_token=None` (and no project, since the SA key spells it `project_id` while the loader reads `project`) that died on the first refresh — `earthengine-api` gates on `refresh_token` the same way. The failure moves from first refresh to construction, and both new errors subclass `CredentialsResolutionError`, which these paths did not raise before, so `except CredentialsResolutionError` now catches strictly more than it did. The new parameter is keyword-only with a default. Worth knowing operationally: a service that builds its session at import and currently boots before failing on the first request will now fail at startup.

Files that are unparsable or carry no refresh token now raise `CredentialsFileUnrecognizedError` rather than failing later, and an unreadable file surfaces the underlying `OSError` instead of being reported as malformed. The guard does not apply in a SEPAL home, where resolution is SEPAL-file-only.

Also adds `CredentialMixin.close()` to release the sync `_service` handle, chained from `aclose()` so `await session.aclose()` is the complete teardown.

Version bump left to commitizen. Offline suite passes at each of the three commits (100 tests); the network-dependent tests against sepal.io fail identically on `main`.
