### PR TITLE
ci: bump checkout and setup-python to Node 24 releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,9 +13,9 @@ jobs:
       id-token: write # OIDC for trusted publishing to PyPI
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       #- uses: ./.github/workflows/unit.yaml
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,10 +15,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -34,8 +34,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
           cache: pip


### PR DESCRIPTION
GitHub is forcing our Node 20 action builds onto Node 24 on the runners, which surfaced as a deprecation annotation on the v3.1.0 release run. `actions/checkout` v7.0.1 and `actions/setup-python` v7.0.0 target `node24` natively — I verified `runs.using` in each `action.yml` at the pinned SHA rather than trusting the tag.

SHA pins kept, comments updated to the exact patch version. Nothing in the major jumps affects us: setup-python v7 drops the `pip-install` input (unused here) and v6 was the Node 24 move; checkout v7 blocks fork checkouts for `pull_request_target`/`workflow_run`, neither of which these workflows use. Both need runner >= v2.327.1, which the hosted runners are well past.

`pypa/gh-action-pypi-publish` is left alone — it's a composite action, not Node, so it was never part of the warning.

The test matrix (3.9/3.10/3.11) on this PR is the real verification.