### PR TITLE
ci: bump gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,5 +26,5 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         # Auth via OIDC trusted publisher; no PYPI_PASSWORD needed.


### PR DESCRIPTION
Finishes the Node 24 sweep. v1.14.1 bumped this action's *internal* `actions/setup-python` off Node 20, so the last Node 20 runtime in the release path goes away with it; v1.14.2 moves its internal Twine to v7, which can upload distributions carrying core packaging metadata 2.5. No security content in either.

Still SHA-pinned. It's a composite action with no required inputs and we pass none, so there's no compatibility surface — I checked `action.yml` at the new SHA.

Heads up on verification: `release.yaml` only runs on `release: published` or manual dispatch, so PR CI does not exercise this line. The next release is the first real test. I didn't dispatch the workflow to prove it, because it would try to publish 3.1.0 again and PyPI rejects duplicate versions.