### PR TITLE
fix: scope the session's asyncio state to the running event loop

### DIFF
--- a/eeclient/client.py
+++ b/eeclient/client.py
@@ -11,7 +11,12 @@ from contextlib import asynccontextmanager
 from eeclient.exceptions import EEClientError, EERestException
 from eeclient.models import GEEHeaders, SepalHeaders
 from eeclient.credential_mixin import CredentialMixin
-from eeclient.cache import ResponseCache
+from eeclient.loopstate import (
+    QPS_LIMIT,
+    LoopResourceRegistry,
+    LoopResources,
+    SimpleRateLimiter,
+)
 
 import eeclient.export as _export_module
 import eeclient.data as _operations_module
@@ -29,23 +34,6 @@ logger = logging.getLogger("eeclient")
 
 # Default values that won't raise exceptions during import
 EARTH_ENGINE_API_URL = "https://earthengine.googleapis.com/v1alpha"
-
-
-class SimpleRateLimiter:
-    def __init__(self, qps: float | None):
-        self.qps = qps
-        self._lock = asyncio.Lock()
-        self._next = 0.0
-
-    async def acquire(self):
-        if not self.qps or self.qps <= 0:
-            return
-        async with self._lock:
-            now = asyncio.get_running_loop().time()
-            wait = max(0.0, self._next - now)
-            if wait:
-                await asyncio.sleep(wait)
-            self._next = max(now, self._next) + 1.0 / self.qps
 
 
 class EESession(CredentialMixin):
@@ -72,15 +60,10 @@ class EESession(CredentialMixin):
         Raises:
             EEClientError: If no credential source is provided.
         """
-        self._inflight = asyncio.BoundedSemaphore(30)
-        self._rate = SimpleRateLimiter(60)
-
-        self._auth_refresh_lock = asyncio.Lock()
-
-        self._client: httpx.AsyncClient | None = None
-        self._client_lock = asyncio.Lock()
-
-        self._assets_cache = ResponseCache(ttl=10.0, max_size=100)
+        # Locks, semaphores, tasks and transports each bind to one event loop,
+        # so they are scoped per loop; the session keeps only what survives one.
+        self._loops = LoopResourceRegistry()
+        self._rate = SimpleRateLimiter(QPS_LIMIT)
 
         self.enforce_project_id = enforce_project_id
         super().__init__(sepal_headers, provider=_provider)
@@ -94,6 +77,19 @@ class EESession(CredentialMixin):
                 "Call initialize() or use create() to fetch credentials."
             )
         )
+
+    def _resources(self) -> LoopResources:
+        """The asyncio state belonging to the running loop."""
+        return self._loops.current()
+
+    @property
+    def _assets_cache(self):
+        """The response cache of the running loop.
+
+        Cached entries hold in-flight ``asyncio.Task`` objects, which only the
+        loop that scheduled them can await, so the cache follows the loop.
+        """
+        return self._resources().cache
 
     async def initialize(self) -> "EESession":
         """Asynchronously initialize the session by fetching credentials if needed.
@@ -273,16 +269,17 @@ class EESession(CredentialMixin):
     async def get_headers(self):
         # Only one task refreshes the token; others wait briefly.
         if self.needs_credentials_refresh():
-            async with self._auth_refresh_lock:
+            async with self._resources().auth_refresh_lock:
                 if self.needs_credentials_refresh():  # double-check after lock
                     await self.set_credentials()
         return self.get_current_headers()
 
     async def _ensure_client(self) -> httpx.AsyncClient:
-        if self._client is None:
-            async with self._client_lock:
-                if self._client is None:
-                    self._client = httpx.AsyncClient(
+        resources = self._resources()
+        if resources.client is None:
+            async with resources.client_lock:
+                if resources.client is None:
+                    resources.client = httpx.AsyncClient(
                         http2=True,
                         timeout=httpx.Timeout(connect=60, read=360, write=60, pool=60),
                         limits=httpx.Limits(
@@ -290,7 +287,7 @@ class EESession(CredentialMixin):
                         ),
                         verify=getattr(self, "verify_ssl", True),
                     )
-        return self._client
+        return resources.client
 
     @asynccontextmanager
     async def get_client(self):
@@ -298,14 +295,28 @@ class EESession(CredentialMixin):
         yield client
 
     async def aclose(self):
-        """Full teardown: the async transport plus any sync resources.
+        """Full teardown: every loop's async transport plus the sync resources.
 
-        Must run on the loop that created the ``httpx.AsyncClient``.
+        Callable from any loop that has driven the session. Only the loop that
+        opened a transport may close it, so the running loop's client is closed
+        here and another live loop's client is handed back to that loop; loops
+        that can no longer run have their sockets released directly.
         """
-        if self._client is not None:
-            await self._client.aclose()
-            self._client = None
-        self._assets_cache.clear()
+        try:
+            here = asyncio.get_running_loop()
+        except RuntimeError:
+            here = None
+
+        for loop, resources in self._loops.drain():
+            client = resources.client
+            resources.client = None
+            resources.cache.clear()
+            if client is None:
+                continue
+            if loop is here:
+                await client.aclose()
+            else:
+                asyncio.run_coroutine_threadsafe(client.aclose(), loop)
         self.close()
 
     async def rest_call(
@@ -328,7 +339,7 @@ class EESession(CredentialMixin):
                 headers = (await self.get_headers()).model_dump(by_alias=True)
                 url_with_project = self.set_url_project(url)
 
-                async with self._inflight:
+                async with self._resources().inflight:
                     await self._rate.acquire()
                     async with self.get_client() as client:
 

--- a/eeclient/loopstate.py
+++ b/eeclient/loopstate.py
@@ -1,0 +1,175 @@
+"""Event-loop scoping for the asyncio objects a session owns.
+
+An :class:`~eeclient.client.EESession` lives as long as the process, but every
+asyncio primitive binds to the first event loop that touches it and raises on
+any other: locks and semaphores through ``_LoopBoundMixin``, tasks through the
+loop that scheduled them, and an ``httpx.AsyncClient`` through the transports
+in its connection pool. A session therefore cannot own any of them directly.
+
+Two shapes make this concrete. A host that gives each user session its own loop
+and closes it when that session restarts leaves a process-scoped session holding
+a pool of dead connections. And a sync-to-async bridge drives one session from
+two loops at once — a private ``run_forever`` loop in a background thread for
+the blocking API, the caller's loop for the ``*_async`` API — so "rebuild when
+the old loop closed" is not enough either; there both loops are open.
+
+What is left on the session is what is safe to share: the credentials, and the
+rate limiter, which meters a per-user Earth Engine quota rather than per-loop
+concurrency and so must stay loop-free by construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+import weakref
+from typing import List, Optional, Tuple
+
+import httpx
+
+from eeclient.cache import ResponseCache
+
+logger = logging.getLogger("eeclient")
+
+INFLIGHT_LIMIT = 30
+QPS_LIMIT = 60
+CACHE_TTL = 10.0
+CACHE_SIZE = 100
+
+
+class SimpleRateLimiter:
+    """A process-wide QPS gate, deliberately free of any event loop.
+
+    Earth Engine meters quota per user, so one session needs one gate however
+    many loops drive it; an ``asyncio.Lock`` would bind the gate to whichever
+    loop reached it first. The slot is reserved under a plain lock with no
+    ``await`` inside it and the wait happens after the lock is released, so
+    callers queue on the clock rather than behind each other.
+    """
+
+    def __init__(self, qps: Optional[float]):
+        self.qps = qps
+        self._lock = threading.Lock()
+        self._next = 0.0
+
+    async def acquire(self) -> None:
+        if not self.qps or self.qps <= 0:
+            return
+        with self._lock:
+            now = time.monotonic()
+            start = max(now, self._next)
+            self._next = start + 1.0 / self.qps
+        delay = start - now
+        if delay > 0:
+            await asyncio.sleep(delay)
+
+
+class LoopResources:
+    """Everything a session owns that belongs to exactly one event loop."""
+
+    __slots__ = ("inflight", "auth_refresh_lock", "client_lock", "cache", "client")
+
+    def __init__(self) -> None:
+        self.inflight = asyncio.BoundedSemaphore(INFLIGHT_LIMIT)
+        self.auth_refresh_lock = asyncio.Lock()
+        self.client_lock = asyncio.Lock()
+        self.cache = ResponseCache(ttl=CACHE_TTL, max_size=CACHE_SIZE)
+        self.client: Optional[httpx.AsyncClient] = None
+
+
+def release_sockets(client: httpx.AsyncClient) -> None:
+    """Free a pool whose loop is gone, without touching the dead loop.
+
+    ``aclose()`` is not usable here — it drives transports that belong to a loop
+    which can no longer run, which is the ``write_eof()`` on a closed transport
+    reported in issue #37. Closing the raw sockets instead hands the descriptors
+    back now rather than whenever the cyclic collector next reaches them; uvloop
+    already released them at ``loop.close()``, plain asyncio did not.
+
+    The walk reads httpcore and anyio internals, so it is best effort: a layout
+    change costs deferred cleanup, never an exception.
+    """
+    try:
+        pool = client._transport._pool  # type: ignore[attr-defined]
+        connections = list(pool.connections)
+    except Exception:  # pragma: no cover - depends on httpcore internals
+        return
+    for connection in connections:
+        try:
+            stream = connection._connection._network_stream
+            for attribute in ("_stream", "transport_stream", "_transport"):
+                inner = getattr(stream, attribute, None)
+                if inner is not None:
+                    stream = inner
+            socket = getattr(stream, "_sock", None)
+            if socket is not None:
+                socket.close()
+        except Exception:  # pragma: no cover - depends on httpcore internals
+            continue
+
+
+class LoopResourceRegistry:
+    """Resolves the resources belonging to the running loop.
+
+    Keys are held weakly, so a loop dropped without being closed takes its
+    resources with it. A loop that is closed but still referenced is reaped on
+    the next lookup miss, which is the churn a restarting host loop produces.
+    """
+
+    def __init__(self) -> None:
+        self._by_loop: (
+            "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, LoopResources]"
+        ) = weakref.WeakKeyDictionary()
+        # Two loops can look up resources from two threads at the same moment.
+        self._guard = threading.Lock()
+
+    def __len__(self) -> int:
+        return len(self._by_loop)
+
+    def current(self) -> LoopResources:
+        """Resources for the running loop, built on that loop's first use."""
+        loop = asyncio.get_running_loop()
+        with self._guard:
+            resources = self._by_loop.get(loop)
+            if resources is not None:
+                return resources
+            self._reap()
+            resources = LoopResources()
+            self._by_loop[loop] = resources
+            logger.debug("EESession: opened resources for loop %r", loop)
+            return resources
+
+    def _reap(self) -> None:
+        """Drop the resources of every loop that can no longer run. Call held."""
+        for loop in [loop for loop in self._by_loop if loop.is_closed()]:
+            resources = self._by_loop.pop(loop, None)
+            if resources is None:
+                continue
+            _discard(resources)
+            logger.debug("EESession: reaped resources of closed loop %r", loop)
+
+    def drain(self) -> List[Tuple[asyncio.AbstractEventLoop, LoopResources]]:
+        """Forget every loop, returning those whose client still needs closing.
+
+        Resources of loops that cannot run are released here. The rest are
+        handed back, because only the loop that opened a transport may close it.
+        """
+        with self._guard:
+            entries = list(self._by_loop.items())
+            self._by_loop = weakref.WeakKeyDictionary()
+        pending = []
+        for loop, resources in entries:
+            if loop.is_closed() or not loop.is_running():
+                _discard(resources)
+            else:
+                pending.append((loop, resources))
+        return pending
+
+
+def _discard(resources: LoopResources) -> None:
+    if resources.client is not None:
+        release_sockets(resources.client)
+        resources.client = None
+    resources.cache.clear()

--- a/tests/test_credential_mixin_close.py
+++ b/tests/test_credential_mixin_close.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from eeclient.client import EESession
@@ -59,12 +61,16 @@ def test_close_without_a_service_is_a_no_op():
 def test_close_does_not_touch_an_async_transport():
     """EESession inherits close(); its httpx client still needs `await aclose()`."""
     session = EESession(_provider=_StubProvider())
-    sentinel = object()
-    session._client = sentinel
+    loop = asyncio.new_event_loop()
+    try:
+        client = loop.run_until_complete(session._ensure_client())
 
-    session.close()
+        session.close()
 
-    assert session._client is sentinel
+        assert client.is_closed is False
+    finally:
+        loop.run_until_complete(client.aclose())
+        loop.close()
 
 
 @pytest.mark.asyncio
@@ -73,9 +79,11 @@ async def test_aclose_is_the_complete_teardown():
     session = EESession(_provider=_StubProvider())
     service = _SpyService()
     session._service = service
+    client = await session._ensure_client()
 
     await session.aclose()
 
     assert service.closed == 1
     assert session._service is None
-    assert session._client is None
+    assert client.is_closed
+    assert len(session._loops) == 0

--- a/tests/test_loop_scoping.py
+++ b/tests/test_loop_scoping.py
@@ -1,0 +1,263 @@
+"""A session is process-scoped; asyncio objects are not.
+
+A host that gives every user session its own event loop and closes it on
+restart leaves a shared session holding dead connections. A sync-to-async
+bridge drives one session from two loops at once — a private ``run_forever``
+loop in a background thread for the blocking API, the caller's loop for the
+``*_async`` API. These tests pin the behaviour a shared session must show in
+both situations.
+"""
+
+import asyncio
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from eeclient.client import EESession
+from eeclient.providers import CredentialSnapshot
+
+
+class _StubProvider:
+    """Credentials that never expire and never touch the network."""
+
+    auth_mode = "stub"
+    auth_source = "stub"
+    user = "tester"
+    verify_ssl = True
+
+    def initial_snapshot(self):
+        return CredentialSnapshot(
+            access_token="token",
+            project_id="ee-project",
+            expiry_date=int((time.time() + 3600) * 1000),
+            native=object(),
+        )
+
+    def refresh_sync(self):
+        raise AssertionError("credentials must not be refreshed in these tests")
+
+    async def refresh(self):
+        raise AssertionError("credentials must not be refreshed in these tests")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"  # keep-alive: the pool must hold connections
+
+    def do_GET(self):
+        body = json.dumps({"ok": True}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture(scope="module")
+def url():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{server.server_address[1]}/x"
+    server.shutdown()
+
+
+@pytest.fixture()
+def session():
+    return EESession(_provider=_StubProvider())
+
+
+@pytest.fixture()
+def loop():
+    """A loop the test drives itself; these tests own their event loops."""
+    new = asyncio.new_event_loop()
+    yield new
+    if not new.is_closed():
+        new.close()
+
+
+def _burst(session, url, count):
+    async def run():
+        return await asyncio.gather(
+            *[session.rest_call("GET", url) for _ in range(count)],
+            return_exceptions=True,
+        )
+
+    return run
+
+
+def _failures(results):
+    return [r for r in results if isinstance(r, BaseException)]
+
+
+def test_a_closed_loop_does_not_break_the_next_burst(session, url):
+    """The restart case: the loop the session first used is closed and replaced."""
+    first = asyncio.new_event_loop()
+    first.run_until_complete(_burst(session, url, 12)())
+    first.close()
+
+    second = asyncio.new_event_loop()
+    try:
+        results = second.run_until_complete(_burst(session, url, 12)())
+    finally:
+        second.close()
+
+    assert _failures(results) == []
+
+
+def test_two_live_loops_share_one_session(session, url):
+    """The sync-bridge case: a private loop and the caller's loop, both open."""
+    private = asyncio.new_event_loop()
+    threading.Thread(target=private.run_forever, daemon=True).start()
+    caller = asyncio.new_event_loop()
+
+    async def one():
+        return await session.rest_call("GET", url)
+
+    try:
+        results = []
+        for _ in range(3):
+            results.append(
+                asyncio.run_coroutine_threadsafe(one(), private).result(timeout=30)
+            )
+            results.append(caller.run_until_complete(one()))
+    finally:
+        caller.close()
+        private.call_soon_threadsafe(private.stop)
+
+    assert all(r == {"ok": True} for r in results)
+
+
+def test_one_loop_keeps_one_client(session, url, loop):
+    """Resources are per loop, not per call — the pool must survive between calls."""
+    loop.run_until_complete(_burst(session, url, 2)())
+    first = loop.run_until_complete(session._ensure_client())
+    second = loop.run_until_complete(session._ensure_client())
+
+    assert first is second
+
+
+def test_each_loop_gets_its_own_client(session, url):
+    """Two loops cannot share a transport, so they must not share a client."""
+    first = asyncio.new_event_loop()
+    private = first.run_until_complete(session._ensure_client())
+    second = asyncio.new_event_loop()
+    try:
+        other = second.run_until_complete(session._ensure_client())
+    finally:
+        second.close()
+        first.close()
+
+    assert private is not other
+
+
+def test_an_incomplete_cache_task_does_not_outlive_its_loop(session, url, loop):
+    """A task orphaned by a closed loop must not be awaited from the next one."""
+
+    async def never():
+        await asyncio.sleep(300)
+
+    first = asyncio.new_event_loop()
+
+    async def start_and_abandon():
+        asyncio.ensure_future(session._assets_cache.get_or_fetch("k", never))
+        await asyncio.sleep(0.05)
+
+    first.run_until_complete(start_and_abandon())
+    first.close()
+
+    async def fetch():
+        return await asyncio.wait_for(
+            session._assets_cache.get_or_fetch("k", lambda: _answer(session, url)),
+            timeout=5,
+        )
+
+    assert loop.run_until_complete(fetch()) == {"ok": True}
+
+
+async def _answer(session, url):
+    return await session.rest_call("GET", url)
+
+
+def test_the_rate_limiter_survives_a_loop_change(session):
+    """The limiter guards a per-user quota, so it cannot bind to one loop."""
+    first = asyncio.new_event_loop()
+    first.run_until_complete(_acquire(session, 4)())
+    first.close()
+
+    second = asyncio.new_event_loop()
+    try:
+        second.run_until_complete(_acquire(session, 4)())
+    finally:
+        second.close()
+
+
+def test_the_rate_limiter_paces_across_loops(session):
+    """Two loops share one quota; they must not each get the full rate."""
+    session._rate.qps = 20
+
+    first = asyncio.new_event_loop()
+    started = time.monotonic()
+    first.run_until_complete(_acquire(session, 10)())
+    first.close()
+
+    second = asyncio.new_event_loop()
+    try:
+        second.run_until_complete(_acquire(session, 10)())
+    finally:
+        second.close()
+    elapsed = time.monotonic() - started
+
+    # 20 slots at 20 qps is ~0.95s; a per-loop limiter would finish in half that.
+    assert elapsed > 0.7
+
+
+def _acquire(session, count):
+    async def run():
+        await asyncio.gather(*[session._rate.acquire() for _ in range(count)])
+
+    return run
+
+
+def test_aclose_releases_every_loop_that_ran(session, url):
+    """Teardown reaches the transports of loops other than the calling one."""
+    private = asyncio.new_event_loop()
+    threading.Thread(target=private.run_forever, daemon=True).start()
+    asyncio.run_coroutine_threadsafe(_answer(session, url), private).result(timeout=30)
+
+    caller = asyncio.new_event_loop()
+    try:
+        caller.run_until_complete(_answer(session, url))
+        caller.run_until_complete(session.aclose())
+        # The other loop's client is closed on that loop, so give it a turn.
+        asyncio.run_coroutine_threadsafe(asyncio.sleep(0.2), private).result(timeout=5)
+        remaining = caller.run_until_complete(_ensure_fresh(session))
+    finally:
+        caller.close()
+        private.call_soon_threadsafe(private.stop)
+
+    assert remaining is not None
+
+
+async def _ensure_fresh(session):
+    """After aclose() the session must still be usable, with a new client."""
+    return await session._ensure_client()
+
+
+def test_a_closed_loop_releases_its_resources(session, url):
+    """Repeated loop churn must not accumulate one pool per dead loop."""
+    for _ in range(3):
+        spent = asyncio.new_event_loop()
+        spent.run_until_complete(_answer(session, url))
+        spent.close()
+
+    live = asyncio.new_event_loop()
+    try:
+        live.run_until_complete(_answer(session, url))
+        assert len(session._loops) == 1
+    finally:
+        live.close()


### PR DESCRIPTION
`EESession` is process-scoped, but the asyncio objects it owned are not. Locks, the semaphore, the assets cache (which stores in-flight `asyncio.Task`s) and the httpx pool each bind to the first event loop that touches them. So a shared session broke once its loop was closed and replaced, and whenever a sync-to-async bridge drove it from both a private `run_forever` loop in a background thread and the caller's loop — that second shape is why "rebuild when the old loop closed" isn't enough, since there both loops are open.

Those now live in a per-loop `LoopResources` bundle resolved from the running loop. Closed loops are reaped and their sockets released directly, never through `aclose()`, which is what raises on a dead transport. The rate limiter moves to a `threading.Lock` + `time.monotonic()` so one QPS gate still covers every loop — EE meters quota per user, not per loop — which also removes the serialization point it had while holding an `asyncio.Lock` across `asyncio.sleep()`.

No public API change. `aclose()` is now callable from any loop that drove the session, and the private `_client`, `_client_lock`, `_inflight` and `_auth_refresh_lock` attributes are gone.

9 new tests in `tests/test_loop_scoping.py` cover both failure shapes; each was watched failing first with the exact errors from #14 and #37. Verified on stdlib asyncio and uvloop. Full suite matches `main` — the pre-existing network failure and 9 network errors are unchanged.

Supersedes #15, which can't rebind in practice: its `_has_active_work()` returns True whenever a client exists, so the reload case becomes a permanent `EELoopError`.

Closes #14. Closes #37.
