### PR TITLE
fix: close remote-loop transports instead of firing and forgetting

### DIFF
--- a/eeclient/client.py
+++ b/eeclient/client.py
@@ -13,9 +13,12 @@ from eeclient.models import GEEHeaders, SepalHeaders
 from eeclient.credential_mixin import CredentialMixin
 from eeclient.loopstate import (
     QPS_LIMIT,
+    AsyncSingleFlight,
     LoopResourceRegistry,
     LoopResources,
     SimpleRateLimiter,
+    await_remote_close,
+    release_sockets,
 )
 
 import eeclient.export as _export_module
@@ -64,6 +67,7 @@ class EESession(CredentialMixin):
         # so they are scoped per loop; the session keeps only what survives one.
         self._loops = LoopResourceRegistry()
         self._rate = SimpleRateLimiter(QPS_LIMIT)
+        self._credential_refresh = AsyncSingleFlight()
 
         self.enforce_project_id = enforce_project_id
         super().__init__(sepal_headers, provider=_provider)
@@ -90,6 +94,10 @@ class EESession(CredentialMixin):
         loop that scheduled them can await, so the cache follows the loop.
         """
         return self._resources().cache
+
+    async def set_credentials(self) -> None:
+        """Refresh shared credentials once across every loop using the session."""
+        await self._credential_refresh.run(super().set_credentials)
 
     async def initialize(self) -> "EESession":
         """Asynchronously initialize the session by fetching credentials if needed.
@@ -307,17 +315,31 @@ class EESession(CredentialMixin):
         except RuntimeError:
             here = None
 
-        for loop, resources in self._loops.drain():
-            client = resources.client
-            resources.client = None
-            resources.cache.clear()
-            if client is None:
-                continue
-            if loop is here:
-                await client.aclose()
-            else:
-                asyncio.run_coroutine_threadsafe(client.aclose(), loop)
-        self.close()
+        remote_closes = []
+        try:
+            for loop, resources in self._loops.drain():
+                client = resources.client
+                resources.client = None
+                resources.cache.clear()
+                if client is None:
+                    continue
+                if loop is here:
+                    await client.aclose()
+                    continue
+
+                close = client.aclose()
+                try:
+                    future = asyncio.run_coroutine_threadsafe(close, loop)
+                except RuntimeError:
+                    close.close()
+                    release_sockets(client)
+                else:
+                    remote_closes.append(await_remote_close(client, loop, future))
+
+            if remote_closes:
+                await asyncio.gather(*remote_closes)
+        finally:
+            self.close()
 
     async def rest_call(
         self,

--- a/eeclient/credential_mixin.py
+++ b/eeclient/credential_mixin.py
@@ -101,11 +101,11 @@ class CredentialMixin:
         that callers may assign themselves, so on a stock session this is a
         no-op. Idempotent.
 
-        This does **not** close an async transport. :class:`eeclient.client.EESession`
-        owns an ``httpx.AsyncClient`` that must be closed with ``await aclose()``
-        on the loop that created it — and ``aclose()`` calls this method, so
-        ``await session.aclose()`` is the complete teardown. Reaching for
-        ``contextlib.closing(session)`` instead would leave the transport open.
+        This does **not** close async transports. :class:`eeclient.client.EESession`
+        owns one ``httpx.AsyncClient`` per event loop that drives it; awaiting
+        ``aclose()`` from any of those loops closes them all and then calls this
+        method. Reaching for ``contextlib.closing(session)`` instead would leave
+        those transports open.
         """
         service = self._service
         self._service = None

--- a/eeclient/loopstate.py
+++ b/eeclient/loopstate.py
@@ -21,11 +21,12 @@ concurrency and so must stay loop-free by construction.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import logging
 import threading
 import time
 import weakref
-from typing import List, Optional, Tuple
+from typing import Awaitable, Callable, List, Optional, Tuple
 
 import httpx
 
@@ -66,6 +67,40 @@ class SimpleRateLimiter:
             await asyncio.sleep(delay)
 
 
+class AsyncSingleFlight:
+    """Share one in-progress async operation across event loops."""
+
+    def __init__(self) -> None:
+        self._guard = threading.Lock()
+        self._pending: Optional[concurrent.futures.Future] = None
+
+    async def run(self, operation: Callable[[], Awaitable[None]]) -> None:
+        with self._guard:
+            pending = self._pending
+            if pending is None:
+                pending = concurrent.futures.Future()
+                self._pending = pending
+                leader = True
+            else:
+                leader = False
+
+        if not leader:
+            await asyncio.shield(asyncio.wrap_future(pending))
+            return
+
+        try:
+            await operation()
+        except BaseException as error:
+            pending.set_exception(error)
+            raise
+        else:
+            pending.set_result(None)
+        finally:
+            with self._guard:
+                if self._pending is pending:
+                    self._pending = None
+
+
 class LoopResources:
     """Everything a session owns that belongs to exactly one event loop."""
 
@@ -88,8 +123,9 @@ def release_sockets(client: httpx.AsyncClient) -> None:
     back now rather than whenever the cyclic collector next reaches them; uvloop
     already released them at ``loop.close()``, plain asyncio did not.
 
-    The walk reads httpcore and anyio internals, so it is best effort: a layout
-    change costs deferred cleanup, never an exception.
+    Locating the network stream still reads httpcore internals, so this is best
+    effort: a layout change costs deferred cleanup, never an exception. Once
+    found, prefer its socket accessor over depending on anyio's wrapper layout.
     """
     try:
         pool = client._transport._pool  # type: ignore[attr-defined]
@@ -97,6 +133,15 @@ def release_sockets(client: httpx.AsyncClient) -> None:
     except Exception:  # pragma: no cover - depends on httpcore internals
         return
     for connection in connections:
+        try:
+            stream = connection._connection._network_stream
+            socket = stream.get_extra_info("socket")
+            socket = getattr(socket, "_sock", socket)
+            if socket is not None and hasattr(socket, "close"):
+                socket.close()
+                continue
+        except Exception:  # pragma: no cover - depends on httpcore internals
+            pass
         try:
             stream = connection._connection._network_stream
             for attribute in ("_stream", "transport_stream", "_transport"):
@@ -108,6 +153,26 @@ def release_sockets(client: httpx.AsyncClient) -> None:
                 socket.close()
         except Exception:  # pragma: no cover - depends on httpcore internals
             continue
+
+
+async def await_remote_close(
+    client: httpx.AsyncClient,
+    loop: asyncio.AbstractEventLoop,
+    future: concurrent.futures.Future,
+) -> None:
+    """Wait for a client close, falling back if its loop stops first."""
+    wrapped = asyncio.wrap_future(future)
+    while True:
+        done, _ = await asyncio.wait((wrapped,), timeout=0.05)
+        if done:
+            await wrapped
+            return
+        # Scheduling can succeed just before a queued loop.stop(), leaving the
+        # coroutine parked forever on a loop that will not take another turn.
+        if not loop.is_running():
+            future.cancel()
+            release_sockets(client)
+            return
 
 
 class LoopResourceRegistry:

--- a/tests/test_loop_scoping.py
+++ b/tests/test_loop_scoping.py
@@ -10,13 +10,16 @@ both situations.
 
 import asyncio
 import json
+import socket
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
 
 import pytest
 
 from eeclient.client import EESession
+from eeclient.loopstate import release_sockets
 from eeclient.providers import CredentialSnapshot
 
 
@@ -41,6 +44,32 @@ class _StubProvider:
 
     async def refresh(self):
         raise AssertionError("credentials must not be refreshed in these tests")
+
+
+class _ConcurrentRefreshProvider(_StubProvider):
+    """Expired credentials whose refresh exposes duplicate cross-loop work."""
+
+    def __init__(self):
+        self.calls = 0
+        self._guard = threading.Lock()
+        self._refreshers = threading.Barrier(2)
+
+    def initial_snapshot(self):
+        return None
+
+    async def refresh(self):
+        with self._guard:
+            self.calls += 1
+        try:
+            await asyncio.to_thread(self._refreshers.wait, 0.5)
+        except threading.BrokenBarrierError:
+            pass
+        return CredentialSnapshot(
+            access_token="refreshed-token",
+            project_id="ee-project",
+            expiry_date=int((time.time() + 3600) * 1000),
+            native=object(),
+        )
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -94,6 +123,46 @@ def _failures(results):
     return [r for r in results if isinstance(r, BaseException)]
 
 
+def _wait_until(predicate, timeout=5):
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("condition was not met before the deadline")
+        time.sleep(0.01)
+
+
+def _pooled_sockets(client):
+    connections = client._transport._pool.connections
+    return [
+        connection._connection._network_stream.get_extra_info("socket")
+        for connection in connections
+    ]
+
+
+def test_release_sockets_uses_the_network_stream_socket_accessor():
+    """Cleanup must not depend on a particular anyio stream-wrapper layout."""
+    owned, peer = socket.socketpair()
+    stream = SimpleNamespace(
+        get_extra_info=lambda name: owned if name == "socket" else None
+    )
+    client = SimpleNamespace(
+        _transport=SimpleNamespace(
+            _pool=SimpleNamespace(
+                connections=[
+                    SimpleNamespace(_connection=SimpleNamespace(_network_stream=stream))
+                ]
+            )
+        )
+    )
+
+    try:
+        release_sockets(client)
+        assert owned.fileno() == -1
+    finally:
+        owned.close()
+        peer.close()
+
+
 def test_a_closed_loop_does_not_break_the_next_burst(session, url):
     """The restart case: the loop the session first used is closed and replaced."""
     first = asyncio.new_event_loop()
@@ -132,6 +201,41 @@ def test_two_live_loops_share_one_session(session, url):
     assert all(r == {"ok": True} for r in results)
 
 
+def test_two_live_loops_share_one_credential_refresh():
+    """Shared credentials must not be refreshed concurrently by two loops."""
+    provider = _ConcurrentRefreshProvider()
+    session = EESession(_provider=provider)
+    start = threading.Barrier(2)
+    loops = [asyncio.new_event_loop(), asyncio.new_event_loop()]
+    threads = [threading.Thread(target=loop.run_forever, daemon=True) for loop in loops]
+    for thread in threads:
+        thread.start()
+
+    async def get_headers_together():
+        start.wait()
+        return await session.get_headers()
+
+    try:
+        futures = [
+            asyncio.run_coroutine_threadsafe(get_headers_together(), loop)
+            for loop in loops
+        ]
+        headers = [future.result(timeout=5) for future in futures]
+    finally:
+        for loop in loops:
+            loop.call_soon_threadsafe(loop.stop)
+        for thread in threads:
+            thread.join(timeout=5)
+        for loop in loops:
+            loop.close()
+
+    assert provider.calls == 1
+    assert [header.authorization for header in headers] == [
+        "Bearer refreshed-token",
+        "Bearer refreshed-token",
+    ]
+
+
 def test_one_loop_keeps_one_client(session, url, loop):
     """Resources are per loop, not per call — the pool must survive between calls."""
     loop.run_until_complete(_burst(session, url, 2)())
@@ -155,8 +259,8 @@ def test_each_loop_gets_its_own_client(session, url):
     assert private is not other
 
 
-def test_an_incomplete_cache_task_does_not_outlive_its_loop(session, url, loop):
-    """A task orphaned by a closed loop must not be awaited from the next one."""
+def test_a_cancelled_cache_task_does_not_outlive_its_loop(session, url, loop):
+    """A cached task from a closed loop must not be read from the next one."""
 
     async def never():
         await asyncio.sleep(300)
@@ -164,10 +268,13 @@ def test_an_incomplete_cache_task_does_not_outlive_its_loop(session, url, loop):
     first = asyncio.new_event_loop()
 
     async def start_and_abandon():
-        asyncio.ensure_future(session._assets_cache.get_or_fetch("k", never))
+        task = asyncio.ensure_future(session._assets_cache.get_or_fetch("k", never))
         await asyncio.sleep(0.05)
+        return task
 
-    first.run_until_complete(start_and_abandon())
+    abandoned = first.run_until_complete(start_and_abandon())
+    abandoned.cancel()
+    first.run_until_complete(asyncio.gather(abandoned, return_exceptions=True))
     first.close()
 
     async def fetch():
@@ -233,14 +340,103 @@ def test_aclose_releases_every_loop_that_ran(session, url):
     try:
         caller.run_until_complete(_answer(session, url))
         caller.run_until_complete(session.aclose())
-        # The other loop's client is closed on that loop, so give it a turn.
-        asyncio.run_coroutine_threadsafe(asyncio.sleep(0.2), private).result(timeout=5)
         remaining = caller.run_until_complete(_ensure_fresh(session))
     finally:
         caller.close()
         private.call_soon_threadsafe(private.stop)
 
     assert remaining is not None
+
+
+def test_aclose_waits_for_clients_on_other_loops(session):
+    """Teardown is not complete until a remote loop has closed its client."""
+    private = asyncio.new_event_loop()
+    caller = asyncio.new_event_loop()
+    loops = [private, caller]
+    threads = [
+        threading.Thread(target=event_loop.run_forever, daemon=True)
+        for event_loop in loops
+    ]
+    for thread in threads:
+        thread.start()
+
+    client = asyncio.run_coroutine_threadsafe(session._ensure_client(), private).result(
+        timeout=5
+    )
+    blocked = threading.Event()
+    release = threading.Event()
+
+    def block_private_loop():
+        blocked.set()
+        release.wait(timeout=5)
+
+    private.call_soon_threadsafe(block_private_loop)
+    assert blocked.wait(timeout=5)
+    close_future = asyncio.run_coroutine_threadsafe(session.aclose(), caller)
+
+    try:
+        with pytest.raises(TimeoutError):
+            close_future.result(timeout=0.1)
+    finally:
+        release.set()
+        close_future.result(timeout=5)
+        for event_loop in loops:
+            event_loop.call_soon_threadsafe(event_loop.stop)
+        for thread in threads:
+            thread.join(timeout=5)
+        for event_loop in loops:
+            event_loop.close()
+
+    assert client.is_closed
+
+
+def test_aclose_falls_back_when_the_remote_loop_stops(session, url):
+    """A loop stopping after close is scheduled must not hang teardown."""
+    private = asyncio.new_event_loop()
+    caller = asyncio.new_event_loop()
+    loops = [private, caller]
+    threads = [
+        threading.Thread(target=event_loop.run_forever, daemon=True)
+        for event_loop in loops
+    ]
+    for thread in threads:
+        thread.start()
+
+    asyncio.run_coroutine_threadsafe(_answer(session, url), private).result(timeout=5)
+    client = asyncio.run_coroutine_threadsafe(session._ensure_client(), private).result(
+        timeout=5
+    )
+    sockets = _pooled_sockets(client)
+    assert sockets
+
+    blocked = threading.Event()
+    release = threading.Event()
+
+    def block_private_loop():
+        blocked.set()
+        release.wait(timeout=5)
+
+    private.call_soon_threadsafe(block_private_loop)
+    assert blocked.wait(timeout=5)
+    private.call_soon_threadsafe(private.stop)
+    close_future = asyncio.run_coroutine_threadsafe(session.aclose(), caller)
+
+    try:
+        _wait_until(lambda: len(session._loops) == 0)
+        release.set()
+        close_future.result(timeout=2)
+        assert all(sock.fileno() == -1 for sock in sockets)
+    finally:
+        release.set()
+        if not close_future.done():
+            close_future.cancel()
+        threads[0].join(timeout=5)
+        if not private.is_running():
+            private.run_until_complete(asyncio.sleep(0))
+        caller.call_soon_threadsafe(caller.stop)
+        threads[1].join(timeout=5)
+        for event_loop in loops:
+            event_loop.close()
 
 
 async def _ensure_fresh(session):
@@ -250,14 +446,20 @@ async def _ensure_fresh(session):
 
 def test_a_closed_loop_releases_its_resources(session, url):
     """Repeated loop churn must not accumulate one pool per dead loop."""
+    spent_sockets = []
     for _ in range(3):
         spent = asyncio.new_event_loop()
         spent.run_until_complete(_answer(session, url))
+        client = spent.run_until_complete(session._ensure_client())
+        sockets = _pooled_sockets(client)
+        assert sockets
+        spent_sockets.extend(sockets)
         spent.close()
 
     live = asyncio.new_event_loop()
     try:
         live.run_until_complete(_answer(session, url))
         assert len(session._loops) == 1
+        assert all(sock.fileno() == -1 for sock in spent_sockets)
     finally:
         live.close()

--- a/tests/test_loop_scoping.py
+++ b/tests/test_loop_scoping.py
@@ -9,6 +9,7 @@ both situations.
 """
 
 import asyncio
+import concurrent.futures
 import json
 import socket
 import threading
@@ -375,7 +376,9 @@ def test_aclose_waits_for_clients_on_other_loops(session):
     close_future = asyncio.run_coroutine_threadsafe(session.aclose(), caller)
 
     try:
-        with pytest.raises(TimeoutError):
+        # Not the builtin: concurrent.futures.TimeoutError only became an alias
+        # for it in 3.11, and before that it derives from Exception, not OSError.
+        with pytest.raises(concurrent.futures.TimeoutError):
             close_future.result(timeout=0.1)
     finally:
         release.set()


### PR DESCRIPTION
Follow-up from a Codex review of #38, which found a real defect in what merged there.

`aclose()` scheduled `client.aclose()` on another live loop with `run_coroutine_threadsafe` and dropped the returned future. Scheduling can succeed just before a queued `loop.stop()`, so that close never ran and the pool's sockets stayed open — a leak on exactly the teardown path meant to prevent one. `await_remote_close()` now waits on the future, and when the target loop is no longer running it cancels and calls `release_sockets()` directly. The regression test blocks the private loop, queues `stop()` ahead of the close, and asserts the real pooled descriptors end up closed.

Two smaller items, both residuals called out in #38:

- `AsyncSingleFlight` folds credential refresh into one shared operation across loops, so two loops no longer each refresh the token. The per-loop `auth_refresh_lock` still coalesces within a loop.
- `release_sockets()` now reads the socket via the network stream's `get_extra_info("socket")`, keeping the anyio wrapper walk only as a fallback. Less private-layout dependence.

`test_a_closed_loop_releases_its_resources` was also strengthened to assert the spent loops' descriptors are actually closed, rather than just that the registry shrank.

One trade-off worth a reviewer's eye: single-flight makes followers wait on the leader's refresh, so if the leader's loop dies mid-refresh the followers wait on a future that never resolves. The window is one short token request, and the previous behaviour traded that risk for duplicate refreshes. Flagging it rather than changing it.

Tests: 113 pass (109 before), stable over 5 consecutive runs of the concurrency file.
