### PR TITLE
Raise minimum Python to 3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 3.1.2
+
+### Packaging
+
+- `tenacity` is no longer a dependency. It was declared but never imported — the
+  retry logic in `rest_call` is hand-rolled — so it was pulling an unused package
+  into every install.
+
+- `eeclient/oauth_app.py` is no longer installed. It is a local development helper
+  (hardcoded client-secret path, `exit(1)` at import time) whose `flask` import
+  lives only in the `dev` extra, so `import eeclient.oauth_app` failed on any real
+  install. It now lives in `scripts/`, outside the package. Nothing in the library
+  imported it.
+
+### Behavior changes
+
+- The minimum supported Python is now **3.10**. Nothing in the code required it,
+  but `earthengine-api`, `google-auth` and `requests` have all moved their own
+  floor to 3.10, so a 3.9 install resolved year-old versions of them.
+
 ## 3.1.1
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,12 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
 
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 urls = {Homepage = "https://github.com/dfguerrerom/ee-client"}
 
 [project.optional-dependencies]


### PR DESCRIPTION
`requires-python` claimed `>=3.9`, but `earthengine-api` (1.7.42), `google-auth` (2.57.1) and `requests` (2.34.2) have all moved their own floor to `>=3.10`. The 3.9 CI job passed only because pip resolved year-old versions of those three, so the 3.9 tier was never really being tested against the stack we ship on.

Drops 3.9 from the test matrix and the classifiers, and adds the 3.1.2 changelog section covering this plus the two packaging fixes from #40.

This also settles the floor for conda-forge, where the latest re-render would otherwise publish the package as `python >=3.11`; the feedstock will pin `python_min` to 3.10 to match.